### PR TITLE
Make 8-bit matrix multiplication compatible with cpuonly builds

### DIFF
--- a/bitsandbytes/__init__.py
+++ b/bitsandbytes/__init__.py
@@ -3,18 +3,18 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-from .autograd._functions import (
-    MatmulLtState,
-    bmm_cublas,
-    matmul,
-    matmul_cublas,
-    mm_cublas,
-)
 from .cextension import COMPILED_WITH_CUDA
 from .nn import modules
 from . import cuda_setup
 
 if COMPILED_WITH_CUDA:
+    from .autograd._functions import (
+        MatmulLtState,
+        bmm_cublas,
+        matmul,
+        matmul_cublas,
+        mm_cublas,
+    )
     from .optim import adam
 
 __pdoc__ = {

--- a/bitsandbytes/autograd/_functions.py
+++ b/bitsandbytes/autograd/_functions.py
@@ -1,10 +1,12 @@
 import operator
-import torch
-import bitsandbytes as bnb
-import bitsandbytes.functional as F
-
 from dataclasses import dataclass
 from functools import reduce  # Required in Python 3
+
+import torch
+
+import bitsandbytes.functional as F
+from bitsandbytes.cextension import COMPILED_WITH_CUDA
+
 
 # math.prod not compatible with python < 3.8
 def prod(iterable):
@@ -165,231 +167,228 @@ mm_cublas = MatMul8bit.apply
 bmm_cublas = MatMul8bit.apply
 matmul_cublas = MatMul8bit.apply
 
+if COMPILED_WITH_CUDA:
+    @dataclass
+    class MatmulLtState:
+        CB = None
+        CxB = None
+        SB = None
+        SCB = None
 
-@dataclass
-class MatmulLtState:
-    CB = None
-    CxB = None
-    SB = None
-    SCB = None
+        CxBt = None
+        SBt = None
+        CBt = None
 
-    CxBt = None
-    SBt = None
-    CBt = None
+        subB = None
 
-    subB = None
+        outlier_pool = None
+        has_accumulated_gradients = False
+        threshold = 0.0
+        idx = None
+        is_training = True
+        has_fp16_weights = True
+        use_pool = False
+        formatB = F.get_special_format_str()
 
-    outlier_pool = None
-    has_accumulated_gradients = False
-    threshold = 0.0
-    idx = None
-    is_training = True
-    has_fp16_weights = True
-    use_pool = False
-    formatB = F.get_special_format_str()
+        def reset_grads(self):
+            self.CB = None
+            self.CxB = None
+            self.SB = None
+            self.SCB = None
 
-    def reset_grads(self):
-        self.CB = None
-        self.CxB = None
-        self.SB = None
-        self.SCB = None
+            self.CxBt = None
+            self.SBt = None
+            self.CBt = None
+    
 
-        self.CxBt = None
-        self.SBt = None
-        self.CBt = None
+    class MatMul8bitLt(torch.autograd.Function):
+        @staticmethod
+        def forward(ctx, A, B, out=None, bias=None, state=MatmulLtState()):
+            # default to pytorch behavior if inputs are empty
+            ctx.is_empty = False
+            if prod(A.shape) == 0:
+                ctx.is_empty = True
+                ctx.A = A
+                ctx.B = B
+                ctx.bias = bias
+                if A.shape[-1] == B.shape[0]:
+                    return torch.empty(A.shape[:-1]+B.shape[1:], dtype=torch.float16, device=A.device)
+                else:
+                    return torch.empty(A.shape[:-1]+B.shape[:1], dtype=torch.float16, device=A.device)
 
+            # 1. Quantize A
+            # 2. Quantize B
+            # 3. Matmul
+            # 4. Mixed-precision decomposition matmul
+            # 5. Save state
+            requires_gradA = A.requires_grad
+            requires_gradB = B.requires_grad
+            requires_gradBias = bias is not None and bias.requires_grad
+            formatB = state.formatB
+            input_shape = A.shape
+            if state.outlier_pool is None:
+                state.outlier_pool = GlobalOutlierPooler.get_instance()
+            assert (
+                A.dtype == torch.float16
+            ), f"The input data type needs to be fp16 but {A.dtype} was found!"
 
-class MatMul8bitLt(torch.autograd.Function):
-    @staticmethod
-    def forward(ctx, A, B, out=None, bias=None, state=MatmulLtState()):
-        # default to pytorch behavior if inputs are empty
-        ctx.is_empty = False
-        if prod(A.shape) == 0:
-            ctx.is_empty = True
-            ctx.A = A
-            ctx.B = B
-            ctx.bias = bias
-            if A.shape[-1] == B.shape[0]:
-                return torch.empty(A.shape[:-1]+B.shape[1:], dtype=torch.float16, device=A.device)
-            else:
-                return torch.empty(A.shape[:-1]+B.shape[:1], dtype=torch.float16, device=A.device)
-
-        # 1. Quantize A
-        # 2. Quantize B
-        # 3. Matmul
-        # 4. Mixed-precision decomposition matmul
-        # 5. Save state
-        requires_gradA = A.requires_grad
-        requires_gradB = B.requires_grad
-        requires_gradBias = bias is not None and bias.requires_grad
-        formatB = state.formatB
-        input_shape = A.shape
-        if state.outlier_pool is None:
-            state.outlier_pool = GlobalOutlierPooler.get_instance()
-        assert (
-            A.dtype == torch.float16
-        ), f"The input data type needs to be fp16 but {A.dtype} was found!"
-
-        # 1. Quantize A
-        if len(A.shape) == 3:
-            A = A.view(-1, A.shape[-1]).contiguous()
-        CA, CAt, SCA, SCAt, coo_tensorA = F.double_quant(
-            A, threshold=state.threshold
-        )
-
-        if state.threshold > 0.0 and coo_tensorA is not None:
-            if state.has_fp16_weights:
-                idx = torch.unique(coo_tensorA.colidx).long()
-                CA[:, idx] = 0
-                CAt[:, idx] = 0
-                subA = A[:, idx]
-                state.subB = B[:, idx].t().contiguous()
-                state.idx = idx
-            else:
-                if state.CxB is None:
-                    # B in in 8-bit row-major, we can transform it back to 16-bit to extract outlier dimensions
-                    # we also need to convert it to the turing/ampere format
-                    state.CxB, state.SB = F.transform(state.CB, to_order=formatB)
-        else:
-            if not state.has_fp16_weights and state.CxB is None:
-                state.CxB, state.SB = F.transform(state.CB, to_order=formatB)
-            subA = None
-
-        # 2. Quantize B
-        if state.has_fp16_weights:
-            has_grad = True if (getattr(B, "grad", None) is not None) else False
-            is_transposed = not B.is_contiguous() and B.shape[0] == B.stride(1)
-            if is_transposed:
-                B = B.contiguous()
-
-            if (state.is_training and not has_grad) or state.CxB is None:
-                state.reset_grads()
-                (
-                    CB,
-                    state.CBt,
-                    state.SCB,
-                    state.SCBt,
-                    coo_tensorB,
-                ) = F.double_quant(B)
-                state.CxB, state.SB = F.transform(CB, to_order=formatB)
-        else:
-            has_grad = False
-
-        if coo_tensorA is not None and not state.has_fp16_weights:
-            # extract outliers
-
-            outlier_idx = torch.unique(coo_tensorA.colidx)
-            state.idx = outlier_idx
-            # state.outlier_pool.add_outliers(outlier_idx, A.shape[-1])
-            # if state.use_pool and state.outlier_pool.model_dim == A.shape[-1]:
-            #    # do not use pool for 2nd FFN layer
-            #    state.idx = state.outlier_pool.get_current_outlier_idx().to(A.device)
-            # else:
-            #    state.idx = outlier_idx
-            outliers = F.extract_outliers(state.CxB, state.SB, state.idx.int())
-            state.subB = (
-                (outliers * state.SCB.view(-1, 1) / 127.0)
-                .t()
-                .contiguous()
-                .half()
+            # 1. Quantize A
+            if len(A.shape) == 3:
+                A = A.view(-1, A.shape[-1]).contiguous()
+            CA, CAt, SCA, SCAt, coo_tensorA = F.double_quant(
+                A, threshold=state.threshold
             )
-            CA[:, state.idx.long()] = 0
-            CAt[:, state.idx.long()] = 0
-            subA = A[:, state.idx.long()]
 
-        shapeB = state.SB[0]
+            if state.threshold > 0.0 and coo_tensorA is not None:
+                if state.has_fp16_weights:
+                    idx = torch.unique(coo_tensorA.colidx).long()
+                    CA[:, idx] = 0
+                    CAt[:, idx] = 0
+                    subA = A[:, idx]
+                    state.subB = B[:, idx].t().contiguous()
+                    state.idx = idx
+                else:
+                    if state.CxB is None:
+                        # B in in 8-bit row-major, we can transform it back to 16-bit to extract outlier dimensions
+                        # we also need to convert it to the turing/ampere format
+                        state.CxB, state.SB = F.transform(state.CB, to_order=formatB)
+            else:
+                if not state.has_fp16_weights and state.CxB is None:
+                    state.CxB, state.SB = F.transform(state.CB, to_order=formatB)
+                subA = None
 
-        if len(input_shape) == 3:
-            output_shape = (input_shape[0], input_shape[1], shapeB[0])
-        else:
-            output_shape = (input_shape[0], shapeB[0])
+            # 2. Quantize B
+            if state.has_fp16_weights:
+                has_grad = True if (getattr(B, "grad", None) is not None) else False
+                is_transposed = not B.is_contiguous() and B.shape[0] == B.stride(1)
+                if is_transposed:
+                    B = B.contiguous()
 
-        # 3. Matmul
-        C32A, SA = F.transform(CA, "col32")
-        out32, Sout32 = F.igemmlt(C32A, state.CxB, SA, state.SB)
-        # we apply the fused bias here
-        output = F.mm_dequant(out32, Sout32, SCA, state.SCB, bias=bias)
+                if (state.is_training and not has_grad) or state.CxB is None:
+                    state.reset_grads()
+                    (
+                        CB,
+                        state.CBt,
+                        state.SCB,
+                        state.SCBt,
+                        coo_tensorB,
+                    ) = F.double_quant(B)
+                    state.CxB, state.SB = F.transform(CB, to_order=formatB)
+            else:
+                has_grad = False
 
-        # 4. Mixed-precision decomposition matmul
-        if coo_tensorA is not None and subA is not None:
-            output += torch.matmul(subA, state.subB)
+            if coo_tensorA is not None and not state.has_fp16_weights:
+                # extract outliers
 
-        # 5. Save state
-        ctx.state = state
-
-        ctx.formatB = formatB
-        ctx.grad_shape = input_shape
-        ctx.req_grads = [requires_gradA, requires_gradB, requires_gradBias]
-
-        if requires_gradA or requires_gradB:
-            ctx.tensors = (CAt, subA)
-            ctx.tensor_states = (SCAt, state.idx)
-        else:
-            ctx.tensors = [None, None]
-            ctx.tensor_states = (None, None)
-            ctx.save_for_backward(None, None)
-
-        clone_func = torch.clone if len(output_shape) == 3 else lambda x : x
-        #clone_func = torch.clone
-        return clone_func(output.view(output_shape))
-
-    @staticmethod
-    def backward(ctx, grad_output):
-        if ctx.is_empty:
-            bias_grad = (None if ctx.bias is None else torch.zeros_like(ctx.bias))
-            return torch.zeros_like(ctx.A), torch.zeros_like(ctx.B), None, bias_grad, None
-        req_gradA, req_gradB, req_gradBias = ctx.req_grads
-        CAt, subA = ctx.tensors
-        SCAt, idx = ctx.tensor_states
-        formatB = ctx.formatB
-        state = ctx.state
-        assert (
-            state.has_fp16_weights
-        ), "Backprop only supported for fp16 weights."
-
-        if len(grad_output.shape) == 3:
-            grad_output = grad_output.view(
-                -1, grad_output.shape[-1]
-            ).contiguous()
-
-        grad_A = grad_B = grad_bias = None
-
-        Cgrad, Cgradt, SCgrad, SCgradt, coo_tensor = F.double_quant(grad_output)
-        if req_gradB:
-            CxAt, SAt = F.transform(CAt, formatB, transpose=True)
-            C32grad, Sgrad = F.transform(Cgradt, "col32", transpose=True)
-            gradB32, SgradB32 = F.igemmlt(C32grad, CxAt, Sgrad, SAt)
-            grad_B = F.mm_dequant(gradB32, SgradB32, SCgradt, SCAt)
-            if state.threshold > 0.0 and subA is not None:
-                grad_B[:, idx] += torch.matmul(grad_output.t(), subA)
-
-        if req_gradA:
-            C32grad, Sgrad = F.transform(Cgrad, "col32")
-            if state.CxBt is None:
-                state.CxBt, state.SBt = F.transform(
-                    state.CBt, to_order=formatB, transpose=True
+                outlier_idx = torch.unique(coo_tensorA.colidx)
+                state.idx = outlier_idx
+                # state.outlier_pool.add_outliers(outlier_idx, A.shape[-1])
+                # if state.use_pool and state.outlier_pool.model_dim == A.shape[-1]:
+                #    # do not use pool for 2nd FFN layer
+                #    state.idx = state.outlier_pool.get_current_outlier_idx().to(A.device)
+                # else:
+                #    state.idx = outlier_idx
+                outliers = F.extract_outliers(state.CxB, state.SB, state.idx.int())
+                state.subB = (
+                    (outliers * state.SCB.view(-1, 1) / 127.0)
+                    .t()
+                    .contiguous()
+                    .half()
                 )
-            gradA32, SgradA32 = F.igemmlt(C32grad, state.CxBt, Sgrad, state.SBt)
-            grad_A = F.mm_dequant(gradA32, SgradA32, SCgrad, state.SCBt).view(ctx.grad_shape)
+                CA[:, state.idx.long()] = 0
+                CAt[:, state.idx.long()] = 0
+                subA = A[:, state.idx.long()]
 
-        if req_gradBias:
-            grad_bias = grad_output.sum(0)
+            shapeB = state.SB[0]
 
-        return grad_A, grad_B, None, grad_bias, None
+            if len(input_shape) == 3:
+                output_shape = (input_shape[0], input_shape[1], shapeB[0])
+            else:
+                output_shape = (input_shape[0], shapeB[0])
+
+            # 3. Matmul
+            C32A, SA = F.transform(CA, "col32")
+            out32, Sout32 = F.igemmlt(C32A, state.CxB, SA, state.SB)
+            # we apply the fused bias here
+            output = F.mm_dequant(out32, Sout32, SCA, state.SCB, bias=bias)
+
+            # 4. Mixed-precision decomposition matmul
+            if coo_tensorA is not None and subA is not None:
+                output += torch.matmul(subA, state.subB)
+
+            # 5. Save state
+            ctx.state = state
+
+            ctx.formatB = formatB
+            ctx.grad_shape = input_shape
+            ctx.req_grads = [requires_gradA, requires_gradB, requires_gradBias]
+
+            if requires_gradA or requires_gradB:
+                ctx.tensors = (CAt, subA)
+                ctx.tensor_states = (SCAt, state.idx)
+            else:
+                ctx.tensors = [None, None]
+                ctx.tensor_states = (None, None)
+                ctx.save_for_backward(None, None)
+
+            clone_func = torch.clone if len(output_shape) == 3 else lambda x : x
+            #clone_func = torch.clone
+            return clone_func(output.view(output_shape))
+
+        @staticmethod
+        def backward(ctx, grad_output):
+            if ctx.is_empty:
+                bias_grad = (None if ctx.bias is None else torch.zeros_like(ctx.bias))
+                return torch.zeros_like(ctx.A), torch.zeros_like(ctx.B), None, bias_grad, None
+            req_gradA, req_gradB, req_gradBias = ctx.req_grads
+            CAt, subA = ctx.tensors
+            SCAt, idx = ctx.tensor_states
+            formatB = ctx.formatB
+            state = ctx.state
+            assert (
+                state.has_fp16_weights
+            ), "Backprop only supported for fp16 weights."
+
+            if len(grad_output.shape) == 3:
+                grad_output = grad_output.view(
+                    -1, grad_output.shape[-1]
+                ).contiguous()
+
+            grad_A = grad_B = grad_bias = None
+
+            Cgrad, Cgradt, SCgrad, SCgradt, coo_tensor = F.double_quant(grad_output)
+            if req_gradB:
+                CxAt, SAt = F.transform(CAt, formatB, transpose=True)
+                C32grad, Sgrad = F.transform(Cgradt, "col32", transpose=True)
+                gradB32, SgradB32 = F.igemmlt(C32grad, CxAt, Sgrad, SAt)
+                grad_B = F.mm_dequant(gradB32, SgradB32, SCgradt, SCAt)
+                if state.threshold > 0.0 and subA is not None:
+                    grad_B[:, idx] += torch.matmul(grad_output.t(), subA)
+
+            if req_gradA:
+                C32grad, Sgrad = F.transform(Cgrad, "col32")
+                if state.CxBt is None:
+                    state.CxBt, state.SBt = F.transform(
+                        state.CBt, to_order=formatB, transpose=True
+                    )
+                gradA32, SgradA32 = F.igemmlt(C32grad, state.CxBt, Sgrad, state.SBt)
+                grad_A = F.mm_dequant(gradA32, SgradA32, SCgrad, state.SCBt).view(ctx.grad_shape)
+
+            if req_gradBias:
+                grad_bias = grad_output.sum(0)
+
+            return grad_A, grad_B, None, grad_bias, None
 
 
-matmul = MatMul8bitLt.apply
-
-
-def matmul(
-    A: tensor,
-    B: tensor,
-    out: tensor = None,
-    state: MatmulLtState = None,
-    threshold=0.0,
-    bias=None
-):
-    state = state or MatmulLtState()
-    if threshold > 0.0:
-        state.threshold = threshold
-    return MatMul8bitLt.apply(A, B, out, bias, state)
+    def matmul(
+        A: tensor,
+        B: tensor,
+        out: tensor = None,
+        state: MatmulLtState = None,
+        threshold=0.0,
+        bias=None
+    ):
+        state = state or MatmulLtState()
+        if threshold > 0.0:
+            state.threshold = threshold
+        return MatMul8bitLt.apply(A, B, out, bias, state)

--- a/bitsandbytes/cextension.py
+++ b/bitsandbytes/cextension.py
@@ -47,6 +47,6 @@ try:
 except AttributeError:
     warn(
         "The installed version of bitsandbytes was compiled without GPU support. "
-        "8-bit optimizers and GPU quantization are unavailable."
+        "8-bit optimizers, GPU quantization and matrix multiplication are unavailable."
     )
     COMPILED_WITH_CUDA = False

--- a/bitsandbytes/cuda_setup/main.py
+++ b/bitsandbytes/cuda_setup/main.py
@@ -46,7 +46,7 @@ def get_cuda_version(cuda, cudart_path):
     minor = (version-(major*1000))//10
 
     if major < 11:
-       print('CUDA SETUP: CUDA version lower than 11 are currenlty not supported for LLM.int8(). You will be only to use 8-bit optimizers and quantization routines!!')
+       print('CUDA SETUP: CUDA versions lower than 11 are currently not supported for LLM.int8(). You will be able only to use 8-bit optimizers and quantization routines!!')
 
     return f'{major}{minor}'
 

--- a/bitsandbytes/functional.py
+++ b/bitsandbytes/functional.py
@@ -5,7 +5,6 @@
 import ctypes as ct
 import operator
 import random
-import math
 import torch
 
 from typing import Tuple
@@ -1684,18 +1683,6 @@ def double_quant(
 
     return out_row, out_col, row_stats, col_stats, coo_tensor
 
-
-def get_special_format_str():
-    major, minor = torch.cuda.get_device_capability()
-    if major < 7:
-        print(
-            f"Device with CUDA capability of {major} not supported for 8-bit matmul. Device has no tensor cores!"
-        )
-        assert major >= 7
-
-    if major == 7: return 'col_turing'
-    elif major == 8: return 'col_ampere'
-    else: return 'col_turing'
 
 
 


### PR DESCRIPTION
While trying to use the latest release of bitsandbytes in hivemind, I faced an error after installing the library in a cpuonly mode (both from PyPI and from source): https://github.com/learning-at-home/hivemind/runs/7961913748?check_suite_focus=true#step:8:56

The gist of this error seems to be unprotected usage of `torch.cuda.get_device_capability()`, which fails for non-GPU builds of PyTorch. To handle this, I've moved the corresponding imports in the root of bitsandbytes inside the COMPILED_WITH_CUDA block and also moved the relevant function/class declarations inside the similar block to avoid accidental imports.

The solution appears to work locally (at least the tests pass), happy to improve on the PR if any additional work is needed.