### PR TITLE
Fixes `OSError: File name too long` when environment variable is too long

### DIFF
--- a/bitsandbytes/cuda_setup/paths.py
+++ b/bitsandbytes/cuda_setup/paths.py
@@ -1,3 +1,4 @@
+import errno
 from pathlib import Path
 from typing import Set, Union
 from warnings import warn
@@ -12,17 +13,22 @@ def extract_candidate_paths(paths_list_candidate: str) -> Set[Path]:
 
 
 def remove_non_existent_dirs(candidate_paths: Set[Path]) -> Set[Path]:
-    non_existent_directories: Set[Path] = {
-        path for path in candidate_paths if not path.exists()
-    }
+    existent_directories: Set[Path] = set()
+    for path in candidate_paths:
+        try:
+            if path.exists():
+                existent_directories.add(path)
+        except errno.ENAMETOOLONG:
+            pass
 
+    non_existent_directories: Set[Path] = candidate_paths - existent_directories
     if non_existent_directories:
         warn(
             "WARNING: The following directories listed in your path were found to "
             f"be non-existent: {non_existent_directories}"
         )
 
-    return candidate_paths - non_existent_directories
+    return existent_directories
 
 
 def get_cuda_runtime_lib_paths(candidate_paths: Set[Path]) -> Set[Path]:

--- a/bitsandbytes/cuda_setup/paths.py
+++ b/bitsandbytes/cuda_setup/paths.py
@@ -18,8 +18,9 @@ def remove_non_existent_dirs(candidate_paths: Set[Path]) -> Set[Path]:
         try:
             if path.exists():
                 existent_directories.add(path)
-        except errno.ENAMETOOLONG:
-            pass
+        except OSError as exc:
+            if exc.errno != errno.ENAMETOOLONG:
+                raise exc
 
     non_existent_directories: Set[Path] = candidate_paths - existent_directories
     if non_existent_directories:


### PR DESCRIPTION
Resolves #35

Hello!

### Pull request overview
* Fixes `OSError: File name too long` when environment variable is too long by try-catching for an `OSError`, and ignoring it when it causes an error due to `File name too long`.

### Details
This PR complies with the `EAFP` "easier to ask for forgiveness than permission" style as recommended in the Python [glossary](https://docs.python.org/3/glossary.html). It simply writes out the set comprehension in full and wraps each `path.exists()` call with a `try-except` which simply considers a candidate path to be non-existent whenever it throws `File name too long`.

After this PR, the output of the same program as #35 outputs only
```python
...
bitsandbytes/cuda_setup/paths.py:27: UserWarning: WARNING: The following directories listed in your path were found to be non-existent: {PosixPath('-};\n do\n if [ "${_m [[removed]]
...
```
This is the expected behaviour here.

Lastly, the changes should be equivalently efficient as before.

### Note
It may be possible that `path.exists()` can throw other exceptions that maybe should be ignored as well, but this PR only ignores the `File name too long` exception.

Let me know if you need anything from me at this point!

- Tom Aarsen
