### PR TITLE
Perform check using implicit list length

### DIFF
--- a/bitsandbytes/cuda_setup/main.py
+++ b/bitsandbytes/cuda_setup/main.py
@@ -103,7 +103,7 @@ def get_compute_capability(cuda):
     None.
     """
     ccs = get_compute_capabilities(cuda)
-    if ccs is not None:
+    if ccs:
         # TODO: handle different compute capabilities; for now, take the max
         return ccs[-1]
     return None


### PR DESCRIPTION
Resolves #34 

Hello!

### Pull request overview
* Perform compute capabilities check using implicit list length instead of `ccs is not None`, as `ccs` is always a list, so this `if`-statement is currently always `True`.

## Details
The function within which the exception from #34 occurs:
https://github.com/TimDettmers/bitsandbytes/blob/9b5f2eda8fbd3f042c4af7ed1b870525d4668f2a/bitsandbytes/cuda_setup/main.py#L99-L109
This function takes `ccs` from `get_compute_capabilities`:
https://github.com/TimDettmers/bitsandbytes/blob/9b5f2eda8fbd3f042c4af7ed1b870525d4668f2a/bitsandbytes/cuda_setup/main.py#L65-L95

As you can see, `ccs` is initialized as a list, and is only optionally appended to. In short, it is never `None`, so `ccs is not None` is always `True`, even if `ccs` is an empty list. 

I've resolved this by using the implicit list length check using `if ccs:`. The new traceback from the Colab provided by @justheuristic (Thank you for raising the issue, and providing the Colab) is:

<details>
<summary>Traceback</summary>

```python
===================================BUG REPORT===================================
Welcome to bitsandbytes. For bug reports, please submit your error trace to: https://github.com/TimDettmers/bitsandbytes/issues
For effortless bug reporting copy-paste your error into this form: https://docs.google.com/forms/d/e/1FAIpQLScPB8emS3Thkp66nvqwmjTEgxp8Y9ufuWTzFyr9kJ5AoI47dQ/viewform?usp=sf_link
================================================================================
CUDA_SETUP: WARNING! libcudart.so not found in any environmental path. Searching /usr/local/cuda/lib64...
CUDA SETUP: CUDA runtime path found: /usr/local/cuda/lib64/libcudart.so
CUDA exception! Error code: no CUDA-capable device is detected
CUDA exception! Error code: initialization error
CUDA SETUP: Highest compute capability among GPUs detected: None
CUDA exception! Error code: no CUDA-capable device is detected
CUDA SETUP: CUDA version lower than 11 are currenlty not supported for LLM.int8(). You will be only to use 8-bit optimizers and quantization routines!!
CUDA SETUP: Detected CUDA version 00
CUDA SETUP: TODO: compile library for specific version: libbitsandbytes_cuda00_nocublaslt.so
CUDA SETUP: Defaulting to libbitsandbytes.so...
CUDA SETUP: CUDA detection failed. Either CUDA driver not installed, CUDA not installed, or you have multiple conflicting CUDA libraries!
CUDA SETUP: If you compiled from source, try again with `make CUDA_VERSION=DETECTED_CUDA_VERSION` for example, `make CUDA_VERSION=113`.

/usr/local/lib/python3.7/dist-packages/bitsandbytes/cuda_setup/paths.py:21: UserWarning: WARNING: The following directories listed in your path were found to be non-existent: {PosixPath('/usr/local/nvidia/lib64'), PosixPath('/usr/local/nvidia/lib')}
  "WARNING: The following directories listed in your path were found to "
/usr/local/lib/python3.7/dist-packages/bitsandbytes/cuda_setup/paths.py:99: UserWarning: /usr/local/nvidia/lib:/usr/local/nvidia/lib64 did not contain libcudart.so as expected! Searching further paths...
  f'{candidate_env_vars["LD_LIBRARY_PATH"]} did not contain '
/usr/local/lib/python3.7/dist-packages/bitsandbytes/cuda_setup/paths.py:21: UserWarning: WARNING: The following directories listed in your path were found to be non-existent: {PosixPath('"/usr/local/bin/dap_multiplexer","enableLsp"'), PosixPath('{"kernelManagerProxyPort"'), PosixPath('["--ip=172.28.0.2"],"debugAdapterMultiplexerPath"'), PosixPath('"172.28.0.3","jupyterArgs"'), PosixPath('true}'), PosixPath('6000,"kernelManagerProxyHost"')}
  "WARNING: The following directories listed in your path were found to "
/usr/local/lib/python3.7/dist-packages/bitsandbytes/cuda_setup/paths.py:21: UserWarning: WARNING: The following directories listed in your path were found to be non-existent: {PosixPath('/env/python')}
  "WARNING: The following directories listed in your path were found to "
/usr/local/lib/python3.7/dist-packages/bitsandbytes/cuda_setup/paths.py:21: UserWarning: WARNING: The following directories listed in your path were found to be non-existent: {PosixPath('module'), PosixPath('//ipykernel.pylab.backend_inline')}
  "WARNING: The following directories listed in your path were found to "

---------------------------------------------------------------------------

Exception                                 Traceback (most recent call last)

[<ipython-input-1-49909ea8fb42>](https://localhost:8080/#) in <module>
----> 1 import bitsandbytes

5 frames

[/usr/local/lib/python3.7/dist-packages/bitsandbytes/cextension.py](https://localhost:8080/#) in initialize(self)
     25                 print('CUDA SETUP: CUDA detection failed. Either CUDA driver not installed, CUDA not installed, or you have multiple conflicting CUDA libraries!')
     26                 print('CUDA SETUP: If you compiled from source, try again with `make CUDA_VERSION=DETECTED_CUDA_VERSION` for example, `make CUDA_VERSION=113`.')
---> 27                 raise Exception('CUDA SETUP: Setup Failed!')
     28             self.lib = ct.cdll.LoadLibrary(binary_path)
     29         else:

Exception: CUDA SETUP: Setup Failed!
```
</details>

I would argue that the new traceback is much clearer.

- Tom Aarsen