### PR TITLE
Prevent `AttributeError: 'function' object has no attribute 'add_log_entry'` on logging

### DIFF
--- a/bitsandbytes/cuda_setup/main.py
+++ b/bitsandbytes/cuda_setup/main.py
@@ -27,14 +27,14 @@ def check_cuda_result(cuda, result_val):
     if result_val != 0:
         error_str = ctypes.c_char_p()
         cuda.cuGetErrorString(result_val, ctypes.byref(error_str))
-        CUDASetup.get_instance.add_log_entry(f"CUDA exception! Error code: {error_str.value.decode()}")
+        CUDASetup.get_instance().add_log_entry(f"CUDA exception! Error code: {error_str.value.decode()}")
 
 def get_cuda_version(cuda, cudart_path):
     # https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART____VERSION.html#group__CUDART____VERSION
     try:
         cudart = ctypes.CDLL(cudart_path)
     except OSError:
-        CUDASetup.get_instance.add_log_entry(f'ERROR: libcudart.so could not be read from path: {cudart_path}!')
+        CUDASetup.get_instance().add_log_entry(f'ERROR: libcudart.so could not be read from path: {cudart_path}!')
         return None
 
     version = ctypes.c_int()

--- a/bitsandbytes/cuda_setup/main.py
+++ b/bitsandbytes/cuda_setup/main.py
@@ -54,7 +54,7 @@ def get_cuda_lib_handle():
     try:
         cuda = ctypes.CDLL("libcuda.so")
     except OSError:
-        CUDA_RUNTIME_LIB.get_instance().add_log_entry('CUDA SETUP: WARNING! libcuda.so not found! Do you have a CUDA driver installed? If you are on a cluster, make sure you are on a CUDA machine!')
+        CUDASetup.get_instance().add_log_entry('CUDA SETUP: WARNING! libcuda.so not found! Do you have a CUDA driver installed? If you are on a cluster, make sure you are on a CUDA machine!')
         return None
     check_cuda_result(cuda, cuda.cuInit(0))
 

--- a/bitsandbytes/cuda_setup/paths.py
+++ b/bitsandbytes/cuda_setup/paths.py
@@ -61,7 +61,7 @@ def warn_in_case_of_duplicates(results_paths: Set[Path]) -> None:
             "If you get `CUDA error: invalid device function` errors, the above "
             "might be the cause and the solution is to make sure only one "
             f"{CUDA_RUNTIME_LIB} in the paths that we search based on your env.")
-        CUDASetup.get_instance.add_log_entry(warning_msg, is_warning=True)
+        CUDASetup.get_instance().add_log_entry(warning_msg, is_warning=True)
 
 
 def determine_cuda_runtime_lib_path() -> Union[Path, None]:
@@ -87,7 +87,7 @@ def determine_cuda_runtime_lib_path() -> Union[Path, None]:
         if conda_cuda_libs:
             return next(iter(conda_cuda_libs))
 
-        CUDASetup.get_instance.add_log_entry(f'{candidate_env_vars["CONDA_PREFIX"]} did not contain '
+        CUDASetup.get_instance().add_log_entry(f'{candidate_env_vars["CONDA_PREFIX"]} did not contain '
             f'{CUDA_RUNTIME_LIB} as expected! Searching further paths...', is_warning=True)
 
     if "LD_LIBRARY_PATH" in candidate_env_vars:


### PR DESCRIPTION
Hello!

### Pull request overview
* Ensure that `CUDASetup.get_instance` is called in all situations.
* Change an  instance of the `CUDA_RUNTIME_LIB` string being used in the context of `CUDASetup`.

### Details
In 3 places throughout the codebase, `CUDASetup.get_instance` is used without being called, causing:
```python
     28         error_str = ctypes.c_char_p()
     29         cuda.cuGetErrorString(result_val, ctypes.byref(error_str))
---> 30         CUDASetup.get_instance.add_log_entry(f"CUDA exception! Error code: {error_str.value.decode()}")
     31 
     32 def get_cuda_version(cuda, cudart_path):

AttributeError: 'function' object has no attribute 'add_log_entry'
```
I've resolved this by calling `get_instance` in all cases.

Secondarily, I noticed that `CUDA_RUNTIME_LIB.get_instance().add_log_entry` was used once, which surprised me, as `CUDA_RUNTIME_LIB` is a constant string. I've replaced `CUDA_RUNTIME_LIB` with `CUDASetup`, as that seems like the intended use.

Let me know if you need anything from me at this point!

- Tom Aarsen
