### PR TITLE
Implement proper serialization of Linear8bitLt

### DIFF
--- a/bitsandbytes/autograd/_functions.py
+++ b/bitsandbytes/autograd/_functions.py
@@ -223,7 +223,7 @@ matmul_cublas = MatMul8bit.apply
 
 @dataclass
 class MatmulLtState:
-    tile_indices: Optional[torch.Tensor] = None
+    _tile_indices: Optional[torch.Tensor] = None
     force_no_igemmlt: bool = False
     CB = None
     CxB = None
@@ -262,6 +262,15 @@ class MatmulLtState:
             "col_ampere",
         ), f"please find this assert and manually enter tile size for {self.formatB}"
         return (8, 32) if self.formatB == "col_turing" else (32, 32)
+
+    @property
+    def tile_indices(self):
+        if self._tile_indices is None:
+            device = self.CxB.device
+            transform = lambda x: F.transform(x.to(device), from_order="row", to_order=self.formatB)[0].to(x.device)
+            with torch.no_grad():
+                self._tile_indices = get_inverse_transform_indices(transform, self.get_tile_size()).to(device)
+        return self._tile_indices
 
 
 class MatMul8bitLt(torch.autograd.Function):
@@ -455,13 +464,6 @@ class MatMul8bitLt(torch.autograd.Function):
                 CB = state.CB.to(ctx.dtype_A, copy=True).mul_(state.SCB.unsqueeze(1).mul(1.0 / 127.0))
                 grad_A = torch.matmul(grad_output, CB).view(ctx.grad_shape).to(ctx.dtype_A)
             elif state.CxB is not None:
-
-                if state.tile_indices is None:
-                    order, tile_size = state.formatB, state.get_tile_size()
-                    transform = lambda x: F.transform(x.cuda(), from_order="row", to_order=order)[0].to(x.device)
-                    with torch.no_grad():
-                        state.tile_indices = get_inverse_transform_indices(transform, tile_size).to(state.CxB.device)
-
                 CB = (
                     undo_layout(state.CxB, state.tile_indices)
                     .to(ctx.dtype_A)

--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -236,20 +236,7 @@ class Linear8bitLt(nn.Linear):
 
         try:
             if reorder_layout:
-                if self.state.tile_indices is None:
-                    order, tile_size = self.state.formatB, self.state.get_tile_size()
-                    transform = lambda x: \
-                        bitsandbytes.functional.transform(x.to(self.weight.data.device), from_order="row",
-                                                          to_order=order)[0].to(x.device)
-                    with torch.no_grad():
-                        self.state.tile_indices = get_inverse_transform_indices(transform, tile_size).to(
-                            self.state.CxB.device)
-
-                CB = (
-                    undo_layout(self.state.CxB, self.state.tile_indices)
-                )
-
-                self.weight.data = CB
+                self.weight.data = undo_layout(self.state.CxB, self.state.tile_indices)
 
             super()._save_to_state_dict(destination, prefix, keep_vars)
 

--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -212,7 +212,7 @@ class Int8Params(torch.nn.Parameter):
 
 class Linear8bitLt(nn.Linear):
     def __init__(self, input_features, output_features, bias=True, has_fp16_weights=True,
-                 memory_efficient_backward=False, threshold=0.0, index=None):
+                       memory_efficient_backward=False, threshold=0.0, index=None):
         super().__init__(input_features, output_features, bias)
         assert not memory_efficient_backward, "memory_efficient_backward is no longer required and the argument is deprecated in 0.37.0 and will be removed in 0.39.0"
         self.state = bnb.MatmulLtState()

--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -248,6 +248,11 @@ class Linear8bitLt(nn.Linear):
         for key in unexpected_keys:
             input_name = key[len(prefix):]
             if input_name == "SCB":
+                if self.weight.SCB is None:
+                    # buffers not yet initialized, can't call them directly without
+                    raise RuntimeError("Loading a quantized checkpoint into non-quantized Linear8bitLt is "
+                                       "not supported. Please call module.cuda() before module.load_state_dict()")
+
                 input_param = state_dict[key]
                 self.weight.SCB.copy_(input_param)
                 unexpected_keys.remove(key)


### PR DESCRIPTION
As mentioned in https://github.com/huggingface/transformers/issues/20247 and as often requested by users of https://github.com/bigscience-workshop/petals, it would be very useful to save and load 8-bit quantized parameters of `Linear8bitLt` (e.g., to save bandwidth when downloading large models only for inference). This PR implements that feature by adding the missing `SCB` set of float16 quantized weights to the state dict of the layer. 

Importantly,
1. One needs to first trigger the quantization by calling layer.cuda()
2. To load the weights into the model, one also needs to call layer.cuda() before that to allocate the necessary buffers
3. If `has_fp16_weights` is True, then 8-bit quantized weights are not stored in the state — thus not serialized
4. Loading 8-bit weights into a layer with `has_fp16_weights==True` is not supported, as it would require dequantizing the weights

The test I've implemented handles all combinations of use cases and verifies that loading the serialized weights either results in an exception (if rule 2 is violated) or the same output as before serialization.

cc @borzunov @younesbelkada 