### PR TITLE
Fix #157; Add XDG_GREETER_DATA_DIR to ignorelist

### DIFF
--- a/bitsandbytes/cuda_setup/env_vars.py
+++ b/bitsandbytes/cuda_setup/env_vars.py
@@ -11,6 +11,7 @@ def to_be_ignored(env_var: str, value: str) -> bool:
         "HOME",  # Linux shell default
         "TMUX",  # Terminal Multiplexer
         "XDG_DATA_DIRS",  # XDG: Desktop environment stuff
+        "XDG_GREETER_DATA_DIR",  # XDG: Desktop environment stuff
         "XDG_RUNTIME_DIR",
         "MAIL",  # something related to emails
         "SHELL",  # binary for currently invoked shell


### PR DESCRIPTION
Fixes Issue #157 on Arch with a LightDm by adding the Environment Variable "XDG_GREETER_DATA_DIR" to the ignore list. In particular critical, since in a standard install the folder is not accessible and hence throws a permission error.