### PR TITLE
Fixed typo libsbitsandbytes_cpu.so

### DIFF
--- a/bitsandbytes/cuda_setup/main.py
+++ b/bitsandbytes/cuda_setup/main.py
@@ -365,7 +365,7 @@ def evaluate_cuda_setup():
         print('='*35 + 'BUG REPORT' + '='*35)
         print('Welcome to bitsandbytes. For bug reports, please submit your error trace to: https://github.com/TimDettmers/bitsandbytes/issues')
         print('='*80)
-    if not torch.cuda.is_available(): return 'libsbitsandbytes_cpu.so', None, None, None, None
+    if not torch.cuda.is_available(): return 'libbitsandbytes_cpu.so', None, None, None, None
 
     cuda_setup = CUDASetup.get_instance()
     cudart_path = determine_cuda_runtime_lib_path()


### PR DESCRIPTION
Hello bitsandbytes!

While I was investigating on some problem running `bitsandbytes`, I think I found a typo.

There seems nowhere using `libsbitsandbytes_cpu.so`(lib+s+bitsandbytes_cpu.so), but `libbitsandbytes_cpu.so`(lib+bitsandbytes_cpu.so) is being used.

Thanks in advance!
