### PR TITLE
When using sudo to run the command, the system variable environment is reset and the original environment variable cannot be obtained

### DIFF
--- a/bitsandbytes/cuda_setup/env_vars.py
+++ b/bitsandbytes/cuda_setup/env_vars.py
@@ -54,9 +54,13 @@ def get_potentially_lib_path_containing_env_vars() -> Dict[str, str]:
 
 def restore_original_system_env_vars(env_vars: Dict[str, str]):
     """
+        If the python program was started with `sudo`,
         Use the `sudo -i env` command to obtain the original environment variables of the system, including CONDA_PREFIX, LD_LIBRARY_PATH...
         Then replace the environment variables obtained from the current shell, to obtain correct and complete environment variables
     """
+    if not os.geteuid() == 0:
+        return
+
     output = subprocess.check_output(['sudo', '-i', 'env'])
     output_str = output.decode('utf-8')
     env_lines = output_str.split('\n')

--- a/bitsandbytes/cuda_setup/env_vars.py
+++ b/bitsandbytes/cuda_setup/env_vars.py
@@ -64,10 +64,7 @@ def restore_original_system_env_vars(env_vars: Dict[str, str]):
     if os.geteuid() != 0:
         return
 
-    output = subprocess.check_output(['sudo', '-i', 'env'])
-    output_str = output.decode('utf-8')
-    env_lines = output_str.split('\n')
-    for env_line in env_lines:
+    for env_line in subprocess.check_output(['sudo', '-i', 'env'], encoding="utf-8").splitlines():
         if '=' in env_line:
             key, value = env_line.split('=', 1)
             if (key == "CONDA_PREFIX" or key == "LD_LIBRARY_PATH") and key not in env_vars:

--- a/bitsandbytes/cuda_setup/env_vars.py
+++ b/bitsandbytes/cuda_setup/env_vars.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 from typing import Dict
+from distutils.spawn import find_executable
 
 
 def to_be_ignored(env_var: str, value: str) -> bool:
@@ -54,10 +55,12 @@ def get_potentially_lib_path_containing_env_vars() -> Dict[str, str]:
 
 def restore_original_system_env_vars(env_vars: Dict[str, str]):
     """
-        If the python program was started with `sudo`,
+        If the system supports `sudo` command, and the python program was started with `sudo`,
         Use the `sudo -i env` command to obtain the original environment variables of the system, including CONDA_PREFIX, LD_LIBRARY_PATH...
         Then replace the environment variables obtained from the current shell, to obtain correct and complete environment variables
     """
+    if find_executable('sudo') is None:
+        return
     if not os.geteuid() == 0:
         return
 

--- a/bitsandbytes/cuda_setup/env_vars.py
+++ b/bitsandbytes/cuda_setup/env_vars.py
@@ -53,6 +53,10 @@ def get_potentially_lib_path_containing_env_vars() -> Dict[str, str]:
     }
 
 def restore_original_system_env_vars(env_vars: Dict[str, str]):
+    """
+        Use the `sudo -i env` command to obtain the original environment variables of the system, including CONDA_PREFIX, LD_LIBRARY_PATH...
+        Then replace the environment variables obtained from the current shell, to obtain correct and complete environment variables
+    """
     output = subprocess.check_output(['sudo', '-i', 'env'])
     output_str = output.decode('utf-8')
     env_lines = output_str.split('\n')

--- a/bitsandbytes/cuda_setup/env_vars.py
+++ b/bitsandbytes/cuda_setup/env_vars.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 from typing import Dict
+import shutil
 
 
 def to_be_ignored(env_var: str, value: str) -> bool:

--- a/bitsandbytes/cuda_setup/env_vars.py
+++ b/bitsandbytes/cuda_setup/env_vars.py
@@ -63,5 +63,5 @@ def restore_original_system_env_vars(env_vars: Dict[str, str]):
     for env_line in env_lines:
         if '=' in env_line:
             key, value = env_line.split('=', 1)
-            if key in env_vars:
+            if (key == "CONDA_PREFIX" or key == "LD_LIBRARY_PATH") and key not in env_vars:
                 env_vars[key] = value

--- a/bitsandbytes/cuda_setup/env_vars.py
+++ b/bitsandbytes/cuda_setup/env_vars.py
@@ -61,7 +61,7 @@ def restore_original_system_env_vars(env_vars: Dict[str, str]):
     """
     if find_executable('sudo') is None:
         return
-    if not os.geteuid() == 0:
+    if os.geteuid() != 0:
         return
 
     output = subprocess.check_output(['sudo', '-i', 'env'])

--- a/bitsandbytes/cuda_setup/env_vars.py
+++ b/bitsandbytes/cuda_setup/env_vars.py
@@ -58,7 +58,7 @@ def restore_original_system_env_vars(env_vars: Dict[str, str]):
         Use the `sudo -i env` command to obtain the original environment variables of the system, including CONDA_PREFIX, LD_LIBRARY_PATH...
         Then replace the environment variables obtained from the current shell, to obtain correct and complete environment variables
     """
-    if find_executable('sudo') is None:
+    if shutil.which('sudo') is None:
         return
     if os.geteuid() != 0:
         return

--- a/bitsandbytes/cuda_setup/env_vars.py
+++ b/bitsandbytes/cuda_setup/env_vars.py
@@ -1,7 +1,6 @@
 import os
 import subprocess
 from typing import Dict
-from distutils.spawn import find_executable
 
 
 def to_be_ignored(env_var: str, value: str) -> bool:

--- a/bitsandbytes/cuda_setup/env_vars.py
+++ b/bitsandbytes/cuda_setup/env_vars.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 from typing import Dict
 
 
@@ -50,3 +51,13 @@ def get_potentially_lib_path_containing_env_vars() -> Dict[str, str]:
         for env_var, value in os.environ.items()
         if is_relevant_candidate_env_var(env_var, value)
     }
+
+def restore_original_system_env_vars(env_vars: Dict[str, str]):
+    output = subprocess.check_output(['sudo', '-i', 'env'])
+    output_str = output.decode('utf-8')
+    env_lines = output_str.split('\n')
+    for env_line in env_lines:
+        if '=' in env_line:
+            key, value = env_line.split('=', 1)
+            if key in env_vars:
+                env_vars[key] = value

--- a/bitsandbytes/cuda_setup/main.py
+++ b/bitsandbytes/cuda_setup/main.py
@@ -26,6 +26,7 @@ from itertools import product
 from pathlib import Path
 from typing import Set, Union
 from .env_vars import get_potentially_lib_path_containing_env_vars
+from .env_vars import restore_original_system_env_vars
 
 # these are the most common libs names
 # libcudart.so is missing by default for a conda install with PyTorch 2.0 and instead
@@ -234,6 +235,7 @@ def determine_cuda_runtime_lib_path() -> Union[Path, None]:
         while giving a warning message.
     """
     candidate_env_vars = get_potentially_lib_path_containing_env_vars()
+    restore_original_system_env_vars(candidate_env_vars)
 
     if "CONDA_PREFIX" in candidate_env_vars:
         conda_libs_path = Path(candidate_env_vars["CONDA_PREFIX"]) / "lib"


### PR DESCRIPTION
I get an error while running the program on the linux, 
```
===================================BUG REPORT===================================
Welcome to bitsandbytes. For bug reports, please run

python -m bitsandbytes

 and submit this information together with your error trace to: https://github.com/TimDettmers/bitsandbytes/issues
================================================================================
bin /home/stable-diffusion/kohya_ss/venv/lib/python3.10/site-packages/bitsandbytes/libbitsandbytes_cpu.so
CUDA_SETUP: WARNING! libcudart.so not found in any environmental path. Searching in backup paths...
```
This CUDA_SETUP WARNING looks like the CUDA information was not found. Following the error log, I found this file: https://github.com/TimDettmers/bitsandbytes/blob/9e7cdc9ea95e9756d9f5621a0e2c7e2538363fae/bitsandbytes/cuda_setup/main.py. The determine_cuda_runtime_lib_path method in this file will use the LD_LIBRARY_PATH environment variable to get the CUDA installation path. But I use sudo to run the program, which causes non-basic environment variables to be reset, including LD_LIBRARY_PATH and CONDA_PREFIX, os.environ can only get the environment variables in the current shell, so the original environment variables of the system cannot be obtained.
I try to use sudo -i env to obtain the original environment variables of the system, and fill in the values ​​of CONDA_PREFIX and LD_LIBRARY_PATH that do not exist in env_vars, which can effectively solve my problem.
I think this is a useful optimization point to avoid some potential anomalies brought by the sudo command.