### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ For straight Int8 matrix multiplication with mixed precision decomposition you c
 bnb.matmul(..., threshold=6.0)
 ```
 
-For instructions how to use LLM.int8() inference layers in your own code, see the TL;DR above or for extended instruction see [this blog post](https://github.com/huggingface/transformers).
+For instructions how to use LLM.int8() inference layers in your own code, see the TL;DR above or for extended instruction see [this blog post](https://huggingface.co/blog/hf-bitsandbytes-integration).
 
 ### Using the 8-bit Optimizers
 


### PR DESCRIPTION
### What
When reading the README, I realized that there is a link that is supposed to contain detailed instructions on how to use LLM.int8. However, the link points to the [HF Transformers repo](https://github.com/huggingface/transformers).

### Fix
I assume that the actual blog post the README refers to is ["A Gentle Introduction to 8-bit Matrix Multiplication for transformers at scale using Hugging Face Transformers, Accelerate and bitsandbytes"](https://huggingface.co/blog/hf-bitsandbytes-integration), which is also linked in the "Resources" section.


If my assumption is wrong, do not hesitate to close the PR!