### PR TITLE
add sort to get_compute_capabilities

### DIFF
--- a/bitsandbytes/cuda_setup/main.py
+++ b/bitsandbytes/cuda_setup/main.py
@@ -355,6 +355,7 @@ def get_compute_capabilities(cuda):
         # 2. call extern C function to determine CC
         check_cuda_result(cuda, cuda.cuDeviceComputeCapability(ref_major, ref_minor, device))
         ccs.append(f"{cc_major.value}.{cc_minor.value}")
+    ccs.sort(key=lambda v: tuple(map(int, str(v).split("."))))
 
     return ccs
 


### PR DESCRIPTION
In `get_compute_capability`, the last item of ccs (`ccs[-1]`) will be selected as the maximum compute capability.
But `ccs` are not sorted in `get_compute_capabilities`
This PR adds sorting to `get_compute_capabilities`
