### PR TITLE
fix install bug on __main.py__ #528

### DIFF
--- a/bitsandbytes/__main__.py
+++ b/bitsandbytes/__main__.py
@@ -33,8 +33,14 @@ def execute_and_return(command_string: str) -> Tuple[str, str]:
 def find_file_recursive(folder, filename):
     cmd = f'find {folder} -name {filename}'
     out, err = execute_and_return(cmd)
+
     if len(err) > 0:
-        raise RuntimeError('Something when wrong when trying to find file. Maybe you do not have a linux system?')
+        print("Error information", "*"*80)
+        print(err)
+        if "Permission denied" in err:
+            print("errors are caused by Permission denied, ignore temporarily")
+        else:
+            raise RuntimeError('Something when wrong when trying to find file. Maybe you do not have a linux system?')
 
     return out
 


### PR DESCRIPTION
In a multi-user linux system, some users are not allowed to access other user's directory, however, the function `execute_and_return` try to do so, which would cause Permission denied error. 
So the function `find_file_recursive` raise `RuntimeError('Something when wrong when trying to find file. Maybe you do not have a linux system?')`  whenever `len(err)>0` is not logic. In this case, the  `Permission denied` should be excluded.
Presumably, this commit may partly solve the issue #528 