### PR TITLE
replace private with public https repo URL

### DIFF
--- a/bitsandbytes/cuda_setup/main.py
+++ b/bitsandbytes/cuda_setup/main.py
@@ -86,7 +86,7 @@ class CUDASetup:
             make_cmd += '_nomatmul'
 
         self.add_log_entry('CUDA SETUP: Something unexpected happened. Please compile from source:')
-        self.add_log_entry('git clone git@github.com:TimDettmers/bitsandbytes.git')
+        self.add_log_entry('git clone https://github.com/TimDettmers/bitsandbytes.git')
         self.add_log_entry('cd bitsandbytes')
         self.add_log_entry(make_cmd)
         self.add_log_entry('python setup.py install')


### PR DESCRIPTION
The information log uses git@github format but that's not the public format URL (you need contributor access to clone in this way). This PR replaces it with the public https URL that should work regardless of any authentication.


Error trace before the change
```
$ git clone git@github.com:TimDettmers/bitsandbytes.git
Cloning into 'bitsandbytes'...
Warning: Permanently added 'github.com,140.82.121.3' (ECDSA) to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

Solved after changing the command to https