### PR TITLE
Fix  import crash caused by __main__.py reference to nonexistent cuda_setup.main.get_cuda_lib_handle

### DIFF
--- a/bitsandbytes/__main__.py
+++ b/bitsandbytes/__main__.py
@@ -97,13 +97,12 @@ generate_bug_report_information()
 
 from . import COMPILED_WITH_CUDA, PACKAGE_GITHUB_URL
 from .cuda_setup.env_vars import to_be_ignored
-from .cuda_setup.main import get_compute_capabilities, get_cuda_lib_handle
+from .cuda_setup.main import get_compute_capabilities
 
 
 print_header("OTHER")
 print(f"COMPILED_WITH_CUDA = {COMPILED_WITH_CUDA}")
-cuda = get_cuda_lib_handle()
-print(f"COMPUTE_CAPABILITIES_PER_GPU = {get_compute_capabilities(cuda)}")
+print(f"COMPUTE_CAPABILITIES_PER_GPU = {get_compute_capabilities()}")
 print_header("")
 print_header("DEBUG INFO END")
 print_header("")

--- a/bitsandbytes/cuda_setup/main.py
+++ b/bitsandbytes/cuda_setup/main.py
@@ -360,13 +360,3 @@ def evaluate_cuda_setup():
         binary_name = f"libbitsandbytes_cuda{cuda_version_string}_nocublaslt.so"
 
     return binary_name, cudart_path, cc, cuda_version_string
-
-def get_cuda_lib_handle():
-    # 1. find libcuda.so library (GPU driver) (/usr/lib)
-    try:
-        cuda = ct.CDLL("libcuda.so")
-    except OSError:
-        CUDASetup.get_instance().add_log_entry('CUDA SETUP: WARNING! libcuda.so not found! Do you have a CUDA driver installed? If you are on a cluster, make sure you are on a CUDA machine!')
-        return None
-
-    return cuda

--- a/bitsandbytes/cuda_setup/main.py
+++ b/bitsandbytes/cuda_setup/main.py
@@ -360,3 +360,13 @@ def evaluate_cuda_setup():
         binary_name = f"libbitsandbytes_cuda{cuda_version_string}_nocublaslt.so"
 
     return binary_name, cudart_path, cc, cuda_version_string
+
+def get_cuda_lib_handle():
+    # 1. find libcuda.so library (GPU driver) (/usr/lib)
+    try:
+        cuda = ct.CDLL("libcuda.so")
+    except OSError:
+        CUDASetup.get_instance().add_log_entry('CUDA SETUP: WARNING! libcuda.so not found! Do you have a CUDA driver installed? If you are on a cluster, make sure you are on a CUDA machine!')
+        return None
+
+    return cuda


### PR DESCRIPTION
get_cuda_lib_handle no longer exists and is no longer necessary for determining compute capability, and is causing a crash on importing bitsandbytes. this fix removes all lingering reference to it