### PR TITLE
Fix uncaught error due to except clause ordering

### DIFF
--- a/bitsandbytes/cuda_setup/main.py
+++ b/bitsandbytes/cuda_setup/main.py
@@ -196,11 +196,11 @@ def remove_non_existent_dirs(candidate_paths: Set[Path]) -> Set[Path]:
         try:
             if path.exists():
                 existent_directories.add(path)
+        except PermissionError as pex:
+            pass
         except OSError as exc:
             if exc.errno != errno.ENAMETOOLONG:
                 raise exc
-        except PermissionError as pex:
-            pass
 
     non_existent_directories: Set[Path] = candidate_paths - existent_directories
     if non_existent_directories:


### PR DESCRIPTION
PermissionError is a subclass of OSError.  If you put the OSError except clause first, it will always catch all PermissionErrors.  Reordering the clauses ensures that PermissionErrors are correctly ignored.

Without this, all PermissionErrors will raise.