### PR TITLE
improve `make clean` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,10 @@ ifeq ($(CUDA_HOME),)
 endif
 
 ifndef CUDA_VERSION
+ifneq ($(MAKECMDGOALS),clean)
 $(warning WARNING: CUDA_VERSION not set. Call make with CUDA string, for example: make cuda11x CUDA_VERSION=115 or make cpuonly CUDA_VERSION=CPU)
 CUDA_VERSION:=
+endif
 endif
 
 
@@ -135,10 +137,5 @@ $(ROOT_DIR)/dependencies/cub:
 	cd dependencies/cub; git checkout 1.11.0
 
 clean:
-	rm build/*
-
-cleaneggs:
-	rm -rf *.egg*
-
-cleanlibs:
-	rm ./bitsandbytes/libbitsandbytes*.so
+	rm -rf build/* *.egg*
+	rm -f bitsandbytes/libbitsandbytes*.so


### PR DESCRIPTION
Make `make clean` remove all build artifacts, and do not warn about CUDA_VERSION when simply running 'clean'.

Fixes #532

---

This seems like the least surprising way for `make clean` to behave:
```
$ make cuda12x_nomatmul CUDA_VERSION=121
$ git status --ignored -uall
On branch fix-make-clean
Your branch is ahead of 'origin/main' by 1 commit.
  (use "git push" to publish your local commits)

Ignored files:
  (use "git add -f <file>..." to include in what will be committed)
        bitsandbytes/libbitsandbytes_cuda121_nocublaslt.so
        build/kernels.o
        build/link.o
        build/ops.o

nothing to commit, working tree clean
$ make clean
rm -rf build/* *.egg*
rm -f bitsandbytes/libbitsandbytes*.so
$ git status --ignored -uall
On branch fix-make-clean
Your branch is ahead of 'origin/main' by 1 commit.
  (use "git push" to publish your local commits)

nothing to commit, working tree clean
```