### PR TITLE
Make sure bitsandbytes handles permission errors in the right order

### DIFF
--- a/bitsandbytes/cuda_setup/main.py
+++ b/bitsandbytes/cuda_setup/main.py
@@ -196,11 +196,13 @@ def remove_non_existent_dirs(candidate_paths: Set[Path]) -> Set[Path]:
         try:
             if path.exists():
                 existent_directories.add(path)
+        except PermissionError as pex:
+            # Handle the PermissionError first as it is a subtype of OSError 
+            # https://docs.python.org/3/library/exceptions.html#exception-hierarchy
+            pass
         except OSError as exc:
             if exc.errno != errno.ENAMETOOLONG:
                 raise exc
-        except PermissionError as pex:
-            pass
 
     non_existent_directories: Set[Path] = candidate_paths - existent_directories
     if non_existent_directories:


### PR DESCRIPTION
When trying to run bitsandbytes on GCP, I ran into an unexpected permission error during cuda driver lookup

```
  File "/opt/conda/envs/cubrio-trainer/lib/python3.9/site-packages/bitsandbytes/cuda_setup/main.py", line 201, in remove_non_existent_dirs
    raise exc
  File "/opt/conda/envs/cubrio-trainer/lib/python3.9/site-packages/bitsandbytes/cuda_setup/main.py", line 197, in remove_non_existent_dirs
    if path.exists():
  File "/opt/conda/envs/cubrio-trainer/lib/python3.9/pathlib.py", line 1424, in exists
    self.stat()
  File "/opt/conda/envs/cubrio-trainer/lib/python3.9/pathlib.py", line 1232, in stat
    return self._accessor.stat(self)
PermissionError: [Errno 13] Permission denied: '/root/google_vm_config.lock'
```

I looked at the code and everything appeared correct until I discovered that `PermissionError` is a sub-type of `OSError` and thus the first except clause would catch any permission errors.  This fixes that by swapping the except clauses.