### PR TITLE
bugfix: change order in exception handling

### DIFF
--- a/bitsandbytes/cuda_setup/main.py
+++ b/bitsandbytes/cuda_setup/main.py
@@ -196,11 +196,11 @@ def remove_non_existent_dirs(candidate_paths: Set[Path]) -> Set[Path]:
         try:
             if path.exists():
                 existent_directories.add(path)
+        except PermissionError as pex:
+            pass
         except OSError as exc:
             if exc.errno != errno.ENAMETOOLONG:
                 raise exc
-        except PermissionError as pex:
-            pass
 
     non_existent_directories: Set[Path] = candidate_paths - existent_directories
     if non_existent_directories:


### PR DESCRIPTION
Hi @TimDettmers 👋🏼

It seems, in [this try / except statement](https://github.com/TimDettmers/bitsandbytes/blob/c82f51c0f784d8a43ebcb9cdefbf94e3f3b9c6c3/bitsandbytes/cuda_setup/main.py#L196-L203), that `PermissionError` should be above `OSError`.

In fact, it just happens that `PermissionError` is an instance of `OSError`, which means that any parsed paths that the user don't have access to will raise an exception and interrupt the execution 🙂 

The proposed change is a simple reordering of the `except` statements.