### PR TITLE
Robustness fix: don't break in case of directories without read permission

### DIFF
--- a/bitsandbytes/cuda_setup/main.py
+++ b/bitsandbytes/cuda_setup/main.py
@@ -214,8 +214,11 @@ def get_cuda_runtime_lib_paths(candidate_paths: Set[Path]) -> Set[Path]:
     paths = set()
     for libname in CUDA_RUNTIME_LIBS:
         for path in candidate_paths:
-            if (path / libname).is_file():
-                paths.add(path / libname)
+            try:
+                if (path / libname).is_file():
+                    paths.add(path / libname)
+            except PermissionError:
+                pass
     return paths
 
 


### PR DESCRIPTION
# Fix for bugs

Fixes #675
Fixes #641
Fixes #623

# Description of the changes

Adds a `try...except` check for `PermissionError` exceptions when looking for CUDA libraries in `cuda_setup`. The current code is very eagerly checking for possible directories that could contain CUDA libraries, and it will fail if it encounters a directory such as `/root` where the user doesn't have read permissions.