### PR TITLE
Add ROCm support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ ifeq ($(CUDA_HOME),)
 	CUDA_HOME:= $(shell which nvcc | rev | cut -d'/' -f3- | rev)
 endif
 ifeq ($(ROCM_HOME),)
-	ROCM_HOME:= $(shell which hipcc | rev | cut -d'/' -f4- | rev)
+	ROCM_HOME:= $(shell which hipcc | rev | cut -d'/' -f3- | rev)
 endif
 
 ifneq ($(CUDA_HOME),)

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ ifndef ROCM_TARGET
 $(error ERROR: ROCM_TARGET not set. Call make with ROCM string (see https://www.llvm.org/docs/AMDGPUUsage.html#processors), for example: make hip ROCM_TARGET=gfx1030)
 ROCM_TARGET:=
 endif
+else
+$(warning WARNING: Unable to find hipcc in path, fallback to ROCM_HOME /opt/rocm)
+ROCM_HOME:=/opt/rocm
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -132,10 +132,10 @@ cpuonly: $(BUILD_DIR) env
 	$(GPP) -std=c++14 -shared -fPIC -I $(ROOT_DIR)/csrc -I $(ROOT_DIR)/include $(FILES_CPP) -o ./bitsandbytes/libbitsandbytes_cpu.so
 
 hip: $(BUILD_DIR)
-	$(HIPCC) -std=c++14 -c -fPIC --offload-arch=$(ROCM_TARGET) $(HIP_INCLUDE) -o $(BUILD_DIR)/ops.o -DNO_CUBLASLT -DBITS_AND_BYTES_USE_ROCM $(CSRC)/ops.cu
-	$(HIPCC) -std=c++14 -c -fPIC --offload-arch=$(ROCM_TARGET) $(HIP_INCLUDE) -o $(BUILD_DIR)/kernels.o -DNO_CUBLASLT -DBITS_AND_BYTES_USE_ROCM $(CSRC)/kernels.cu
+	$(HIPCC) -std=c++14 -c -fPIC --offload-arch=$(ROCM_TARGET) $(HIP_INCLUDE) -o $(BUILD_DIR)/ops.o -DNO_CUBLASLT -DBNB_USE_HIP $(CSRC)/ops.cu
+	$(HIPCC) -std=c++14 -c -fPIC --offload-arch=$(ROCM_TARGET) $(HIP_INCLUDE) -o $(BUILD_DIR)/kernels.o -DNO_CUBLASLT -DBNB_USE_HIP $(CSRC)/kernels.cu
 	# HCC is deprecated, but used by hipBLASlt header. Since blas isn't even used doesn't matter, this is just so that it even compiles
-	$(GPP) -std=c++14 -D__HIP_PLATFORM_HCC__ -D__HIP_PLATFORM_AMD__ -DBUILD_CUDA -DBITS_AND_BYTES_USE_ROCM -shared -fPIC $(HIP_INCLUDE) $(BUILD_DIR)/ops.o $(BUILD_DIR)/kernels.o $(FILES_CPP) $(HIP_LIB) -o ./bitsandbytes/libbitsandbytes_hip_nohipblaslt.so
+	$(GPP) -std=c++14 -D__HIP_PLATFORM_HCC__ -D__HIP_PLATFORM_AMD__ -DBUILD_CUDA -DBNB_USE_HIP -shared -fPIC $(HIP_INCLUDE) $(BUILD_DIR)/ops.o $(BUILD_DIR)/kernels.o $(FILES_CPP) $(HIP_LIB) -o ./bitsandbytes/libbitsandbytes_hip_nohipblaslt.so
 
 env:
 	@echo "ENVIRONMENT"

--- a/README.md
+++ b/README.md
@@ -22,15 +22,30 @@ Python >=3.8. Linux distribution (Ubuntu, MacOS, etc.) + CUDA > 10.0.
 In some cases it can happen that you need to compile from source. If this happens please consider submitting a bug report with `python -m bitsandbytes` information. What now follows is some short instructions which might work out of the box if `nvcc` is installed. If these do not work see further below.
 
 Compilation quickstart:
+
 ```bash
 git clone https://github.com/timdettmers/bitsandbytes.git
 cd bitsandbytes
+```
 
+For CUDA
+```bash
 # CUDA_VERSIONS in {110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 120}
 # make argument in {cuda110, cuda11x, cuda12x}
 # if you do not know what CUDA you have, try looking at the output of: python -m bitsandbytes
 CUDA_VERSION=117 make cuda11x
 python setup.py install
+```
+
+For ROCm
+```bash
+# Requiers ROCm 5.6+
+# Check if your GPU supports Wave32 with rocminfo | grep "Wavefront Size"
+# If this doesn't output 32 and instead 64 this library won't work
+
+# Your ROCm target can be found with rocminfo | grep gfx
+ROCM_TARGET=gfx1030 make hip
+pip install .
 ```
 
 **Using Int8 inference with HuggingFace Transformers**

--- a/bitsandbytes/autograd/_functions.py
+++ b/bitsandbytes/autograd/_functions.py
@@ -224,7 +224,7 @@ matmul_cublas = MatMul8bit.apply
 
 def supports_igemmlt(device: torch.device) -> bool:
     """check if this device supports the optimized int8 kernel"""
-    if torch.cuda.get_device_capability(device=device) < (7, 5):
+    if torch.cuda.get_device_capability(device=device) < (7, 5) or torch.version.hip:
         return False
     device_name = torch.cuda.get_device_name(device=device)
     nvidia16_models = ('GTX 1630', 'GTX 1650', 'GTX 1660')  # https://en.wikipedia.org/wiki/GeForce_16_series

--- a/bitsandbytes/cuda_setup/main.py
+++ b/bitsandbytes/cuda_setup/main.py
@@ -338,7 +338,9 @@ def evaluate_cuda_setup():
         cuda_setup.add_log_entry(('Welcome to bitsandbytes. For bug reports, please run\n\npython -m bitsandbytes\n\n'),
               ('and submit this information together with your error trace to: https://github.com/TimDettmers/bitsandbytes/issues'))
         cuda_setup.add_log_entry('='*80)
+
     if not torch.cuda.is_available(): return 'libbitsandbytes_cpu.so', None, None, None
+    if torch.version.hip: return 'libbitsandbytes_hip_nohipblaslt.so', None, None, None
 
     cudart_path = determine_cuda_runtime_lib_path()
     ccs = get_compute_capabilities()

--- a/compile_from_source.md
+++ b/compile_from_source.md
@@ -38,3 +38,16 @@ If you have problems compiling the library with these instructions from source, 
 
 Since 0.39.1 bitsandbytes installed via pip no longer provides Kepler binaries and these need to be compiled from source. Follow the steps above and instead of `cuda11x_nomatmul` etc use `cuda11x_nomatmul_kepler`
 
+## Compilation with ROCm
+
+Since this library requires hipblasLt this only supports **ROCm 5.6+**.
+Works well with these docker images:
+- [rocm/pytorch](https://hub.docker.com/r/rocm/pytorch)
+- [rocm/pytorch-nightly](https://hub.docker.com/r/rocm/pytorch-nightly).
+
+For installation do:
+```bash
+make hip ROCM_TARGET=gfx1030
+pip install .
+```
+see https://www.llvm.org/docs/AMDGPUUsage.html#processors for finding ROCM_TARGET (e.g. gfx1030 for 6800XT,6900XT) or do `rocminfo | grep gfx`.

--- a/csrc/kernels.cu
+++ b/csrc/kernels.cu
@@ -5,7 +5,7 @@
 
 #include <kernels.cuh>
 
-#ifdef BITS_AND_BYTES_USE_ROCM
+#ifdef BNB_USE_HIP
 #include <hip/hip_runtime.h>
 #include <hipcub/hipcub.hpp>
 #include <hipcub/block/block_radix_sort.hpp>
@@ -38,7 +38,7 @@
 #define NUM 4
 #define NUM_BLOCK 4096
 
-#ifndef BITS_AND_BYTES_USE_ROCM
+#ifndef BNB_USE_HIP
 // source: https://stackoverflow.com/questions/17399119/how-do-i-use-atomicmax-on-floating-point-values-in-cuda
 __device__ float atomicMax(float* address, float val) {
   int* address_as_i = reinterpret_cast<int*>(address);

--- a/csrc/kernels.cu
+++ b/csrc/kernels.cu
@@ -745,7 +745,7 @@ __global__ void kQuantizeBlockwise(float * code, T * __restrict__ const A, float
   #else
   const int CUB_NUM_PER_TH=NUM_PER_TH;
   #endif
-  const int DATA_NUM_PER_TH=(DATA_TYPE > 0) ? NUM_PER_TH/2 : NUM_PER_TH;
+  const int DATA_NUM_PER_TH=(DATA_TYPE > 0) ? NUM_PER_TH/2 : CUB_NUM_PER_TH;
 
   const int n_full = gridDim.x * BLOCK_SIZE;
   int valid_items = 0;

--- a/csrc/ops.cu
+++ b/csrc/ops.cu
@@ -5,11 +5,16 @@
 
 #include <ops.cuh>
 #include <kernels.cuh>
-#include <cub/device/device_scan.cuh>
 #include <limits>
 #include <BinSearch.h>
 #include <cassert>
 #include <common.h>
+
+#ifdef BITS_AND_BYTES_USE_ROCM
+#include <hipcub/device/device_scan.hpp>
+#else
+#include <cub/device/device_scan.cuh>
+#endif
 
 
 using namespace BinSearch;

--- a/csrc/ops.cu
+++ b/csrc/ops.cu
@@ -10,7 +10,7 @@
 #include <cassert>
 #include <common.h>
 
-#ifdef BITS_AND_BYTES_USE_ROCM
+#ifdef BNB_USE_HIP
 #include <hipcub/device/device_scan.hpp>
 #else
 #include <cub/device/device_scan.cuh>

--- a/csrc/ops.cuh
+++ b/csrc/ops.cuh
@@ -12,16 +12,66 @@
 #include <unistd.h>
 #include <assert.h>
 
+
+#ifdef BITS_AND_BYTES_USE_ROCM
+// check rocminfo | grep "Wavefront Size". Should be supported on all new GPU's
+// dirty hack to force wavefront_size 32 so this compiles
+// RDNA 2 defaults to 64 which conflicts with kQuantizeBlockwise
+#define __AMDGCN_WAVEFRONT_SIZE 32 
+
+#include <hip/hip_runtime_api.h>
+#include <hip/hip_fp16.h>
+#include <hipblas/hipblas.h>
+#include <hipblaslt/hipblaslt.h> //only using header to allow redefines
+#include <hipsparse/hipsparse.h>
+
+#define cudaPeekAtLastError hipPeekAtLastError
+#define cudaMemset hipMemset
+#define cudaMemAttachHost hipMemAttachHost
+#define cudaMemPrefetchAsync hipMemPrefetchAsync
+#define cudaMallocManaged hipMallocManaged
+#define cudaDevAttrConcurrentManagedAccess hipDeviceAttributeConcurrentManagedAccess
+#define cudaDeviceGetAttribute hipDeviceGetAttribute
+#define cublasGemmEx hipblasGemmEx
+#define cublasStatus_t hipblasStatus_t
+#define CUBLAS_OP_T HIPBLAS_OP_T
+#define CUBLAS_OP_N HIPBLAS_OP_N
+#define CUDA_R_8I HIPBLAS_R_8I
+#define CUDA_R_32I HIPBLAS_R_32I
+#define CUBLAS_STATUS_SUCCESS HIPBLAS_STATUS_SUCCESS
+#define cublasStatus_t hipblasStatus_t
+#define cublasGemmStridedBatchedEx hipblasGemmStridedBatchedEx
+#define cublasOperation_t hipblasOperation_t
+#define cublasLtMatrixLayoutCreate hipblasLtMatrixLayoutCreate
+#define cudaError_t hipError_t
+#define cudaGetErrorString hipGetErrorString
+#define cudaSuccess hipSuccess
+#define cusparseStatus_t hipsparseStatus_t
+#define CUSPARSE_STATUS_SUCCESS HIPSPARSE_STATUS_SUCCESS
+#define cublasStatus_t hipblasStatus_t
+#define CUBLAS_STATUS_SUCCESS HIPBLAS_STATUS_SUCCESS
+#define cublasHandle_t hipblasHandle_t
+#define cublasCreate_v2 hipblasCreate
+#define cusparseHandle_t hipsparseHandle_t
+#define cusparseCreate hipsparseCreate
+#define __nv_bfloat16 hip_bfloat16
+#define cublasLtHandle_t hipblasLtHandle_t
+#define cublasLtCreate hipblasLtCreate
+#define CUBLAS_GEMM_DEFAULT HIPBLAS_GEMM_DEFAULT
+#define CUBLAS_GEMM_DEFAULT_TENSOR_OP HIPBLAS_GEMM_DEFAULT //TODO: HIP didn't have the right one, might cause issues 
+
+#else
 #include <cuda_runtime_api.h>
 #include <cuda_fp16.h>
 #include <cublas_v2.h>
 #include <cublasLt.h>
 #include <cusparse.h>
-#include <vector>
-#include <functional>
 
 #include <thrust/host_vector.h>
 #include <thrust/device_vector.h>
+#endif
+#include <vector>
+#include <functional>
 
 
 

--- a/csrc/ops.cuh
+++ b/csrc/ops.cuh
@@ -13,7 +13,7 @@
 #include <assert.h>
 
 
-#ifdef BITS_AND_BYTES_USE_ROCM
+#ifdef BNB_USE_HIP
 // check rocminfo | grep "Wavefront Size". Should be supported on all new GPU's
 // dirty hack to force wavefront_size 32 so this compiles
 // RDNA 2 defaults to 64 which conflicts with kQuantizeBlockwise

--- a/csrc/ops.cuh
+++ b/csrc/ops.cuh
@@ -14,10 +14,6 @@
 
 
 #ifdef BNB_USE_HIP
-// check rocminfo | grep "Wavefront Size". Should be supported on all new GPU's
-// dirty hack to force wavefront_size 32 so this compiles
-// RDNA 2 defaults to 64 which conflicts with kQuantizeBlockwise
-#define __AMDGCN_WAVEFRONT_SIZE 32 
 
 #include <hip/hip_runtime_api.h>
 #include <hip/hip_fp16.h>
@@ -58,7 +54,7 @@
 #define cublasLtHandle_t hipblasLtHandle_t
 #define cublasLtCreate hipblasLtCreate
 #define CUBLAS_GEMM_DEFAULT HIPBLAS_GEMM_DEFAULT
-#define CUBLAS_GEMM_DEFAULT_TENSOR_OP HIPBLAS_GEMM_DEFAULT //TODO: HIP didn't have the right one, might cause issues 
+#define CUBLAS_GEMM_DEFAULT_TENSOR_OP HIPBLAS_GEMM_DEFAULT
 
 #else
 #include <cuda_runtime_api.h>

--- a/include/Algo-Direct2.h
+++ b/include/Algo-Direct2.h
@@ -93,8 +93,8 @@ private:
         __m128 vxp = _mm_shuffle_ps(xp01, xp23, (1) + (3 << 2) + (1 << 4) + (3 << 6));
 #endif
         IVec<SSE, float> i(u.vec);
-        IVec<SSE, float> vlem = vz < vxm;
-        IVec<SSE, float> vlep = vz < vxp;
+        IVec<SSE, float> vlem = operator< (vz,vxm);
+        IVec<SSE, float> vlep = operator< (vz,vxp);
         i = i + vlem + vlep;
         i.store(pr);
     }
@@ -123,8 +123,8 @@ private:
         __m128d vxp = _mm_shuffle_pd(vx0, vx1, 3);
 
         IVec<SSE, double> i(b1, b0);
-        IVec<SSE, double> vlem = (vz < vxm);
-        IVec<SSE, double> vlep = (vz < vxp);
+        IVec<SSE, double> vlem = operator< (vz, vxm);
+        IVec<SSE, double> vlep = operator< (vz, vxp);
         i = i + vlem + vlep;
 
         union {
@@ -227,8 +227,8 @@ private:
 
 #endif
 
-        IVec<AVX, float> vlem = vz < vxm;
-        IVec<AVX, float> vlep = vz < vxp;
+        IVec<AVX, float> vlem = operator< (vz, vxm);
+        IVec<AVX, float> vlep = operator< (vz, vxp);
         ip = ip + vlem + vlep;
 
         ip.store(pr);
@@ -277,8 +277,8 @@ private:
 //        FVec<AVX, double> vxp = _mm256_insertf128_pd(_mm256_castpd128_pd256(h01p), h23p, 1);
 
         IVec<AVX, double> i(u.vec);
-        IVec<AVX, double> vlem = vz < vxm;
-        IVec<AVX, double> vlep = vz < vxp;
+        IVec<AVX, double> vlem = operator< (vz,vxm);
+        IVec<AVX, double> vlep = operator< (vz,vxp);
         i = i + vlem + vlep;
         i.extractLo32s().store(pr);
     }


### PR DESCRIPTION
Inspired by the llama.cpp ROCm port, I decided to try and use a similar approach for bitsandbytes and worked through the different hipified cuda functions/classes and just redefine them with the HIP equivalents. This only happens if `BNB_USE_HIP` is set and merging this shouldn't affect the CUDA code at all. It's also easier to maintain than keeping a parallel hip code base alive.

This PR adds the target hip to make and works with the most recent version (0.42.0) with ROCm 5.6+ (6.0 included). For installing just do
```bash
# Your ROCM_TARGET can be found with rocminfo | grep gfx
ROCM_TARGET=gfx1030 make hip
pip install .
```

It won't pass all tests as some are igemm or Cuda specific, but all optimizers work in both 8bit and 32bit. I also used this a lot with llama 4-bit interference, that also works. The tests that fail are beside those test_autograd.py and anything with double_quant in its name, I assume that also has to do with matrix multiplication and is expected to fail. 

Besides that igemm / Matrix core support for the more recent AMD GPU's is still impossible because of missing instructions in [hipBLASLt](https://github.com/ROCmSoftwarePlatform/hipBLASLt). There is also an [official fork](https://github.com/ROCmSoftwarePlatform/bitsandbytes/tree/rocm_enabled) which tries to enable it, but doesn't seem finished yet. If you want to use the official fork without hipblasLt @IMbackK provided a [patch](https://github.com/TimDettmers/bitsandbytes/pull/756#issuecomment-1890071326) for it which should work on all ROCm supported GPU's.

I'm making this a draft for now, as it is still not well tested and I haven't really updated the documentation yet. From an actual code standpoint not much will change on my side as I only own a gfx1030 GPU and thus can't test igemm support.


Closes #47, closes #107,  closes #681