### PR TITLE
patch `requires_grad` error for ints

### DIFF
--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -297,6 +297,7 @@ class Int8Params(torch.nn.Parameter):
             CB, CBt, SCB, SCBt, coo_tensorB = bnb.functional.double_quant(B)
             del CBt
             del SCBt
+            self.requires_grad = False
             self.data = CB
             setattr(self, "CB", CB)
             setattr(self, "SCB", SCB)


### PR DESCRIPTION
this patch bypasses the error https://github.com/pytorch/pytorch/issues/83913. In some cases we cannot assume that `requires_grad=False` in the modified block