### PR TITLE
a fix for GCP locks as per Issue #620

### DIFF
--- a/bitsandbytes/cuda_setup/env_vars.py
+++ b/bitsandbytes/cuda_setup/env_vars.py
@@ -8,6 +8,7 @@ def to_be_ignored(env_var: str, value: str) -> bool:
         "OLDPWD",
         "SSH_AUTH_SOCK",  # SSH stuff, therefore unrelated
         "SSH_TTY",
+        "GOOGLE_VM_CONFIG_LOCK_FILE", #avoids issues with Permissions on GCP, covered in- https://github.com/TimDettmers/bitsandbytes/issues/620#issuecomment-1666014197
         "HOME",  # Linux shell default
         "TMUX",  # Terminal Multiplexer
         "XDG_DATA_DIRS",  # XDG: Desktop environment stuff


### PR DESCRIPTION
fix #620

a solution to an issue seen whilst training on GCP, solution proposed by `xaptronic` in the original issue (Tries to access root lock file #620 @ https://github.com/TimDettmers/bitsandbytes/issues/620) solves the root lock issue.


I do not know if there are  negative ramifications for ignoring `GOOGLE_VM_CONFIG_LOCK_FILE` in the library whilst using GCP --  but if there is something worth looking in to, id be happy to investigate in the next few days.