### PR TITLE
Use /usr/bin/env to find the correct path to g++

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 ROOT_DIR := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 
-GPP:= /usr/bin/g++
+GPP:= /usr/bin/env g++
 #GPP:= /sw/gcc/11.2.0/bin/g++
 ifeq ($(CUDA_HOME),)
 	CUDA_HOME:= $(shell which nvcc | rev | cut -d'/' -f3- | rev)


### PR DESCRIPTION
Building the project fails on nixos (and everywhere else g++ is not in a standard path)