### PR TITLE
Fix typehint error

### DIFF
--- a/bitsandbytes/functional.py
+++ b/bitsandbytes/functional.py
@@ -13,7 +13,7 @@ from scipy.stats import norm
 import numpy as np
 
 from functools import reduce  # Required in Python 3
-from typing import Tuple, Any
+from typing import Tuple, Any, Dict
 from torch import Tensor
 from bitsandbytes.utils import pack_dict_to_tensor, unpack_tensor_to_dict
 
@@ -600,7 +600,7 @@ class QuantState:
         return list_repr[idx]
     
     @classmethod
-    def from_dict(cls, qs_dict: dict[str, Any], device: torch.device) -> 'QuantState':
+    def from_dict(cls, qs_dict: Dict[str, Any], device: torch.device) -> 'QuantState':
         """
         unpacks components of state_dict into QuantState
         where necessary, convert into strings, torch.dtype, ints, etc.


### PR DESCRIPTION
The recent 0.41.2 version causes some errors when one tries to install bitsandbytes 

```bash
    class QuantState:
  File "/usr/local/lib/python3.8/site-packages/bitsandbytes/functional.py", line 603, in QuantState
    def from_dict(cls, qs_dict: dict[str, Any], device: torch.device) -> 'QuantState':
TypeError: 'type' object is not subscriptable
```

This PR fixes it - would be great to add this PR in a patch release if possible 🙏 

cc @TimDettmers @poedator @Titus-von-Koeller 