### PR TITLE
fix 4-bit ckpt loading

### DIFF
--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -253,9 +253,11 @@ class Linear4bit(nn.Linear):
             bias_data = state_dict.pop(prefix + "bias", None)
             self.bias.data = bias_data.to(self.bias.data.device)
 
-        self.weight, state_dict = bnb.nn.Params4bit.from_state_dict(
-                        state_dict, prefix=prefix + "weight" + ".", requires_grad=False
-                    )
+        weight_prefix = prefix + "weight" + "."
+        if weight_prefix.rstrip('.') in state_dict:
+            self.weight, state_dict = bnb.nn.Params4bit.from_state_dict(
+                            state_dict, prefix=weight_prefix, requires_grad=False
+                        )
         unexpected_keys.extend(state_dict.keys())
 
     def forward(self, x: torch.Tensor):


### PR DESCRIPTION
Code to test:

```
from transformers import AutoModelForCausalLM, AutoTokenizer

from peft import PeftModel

model = AutoModelForCausalLM.from_pretrained("meta-llama/Llama-2-7b-chat-hf", load_in_4bit=True, device_map={"":0})
tokenizer = AutoTokenizer.from_pretrained("meta-llama/Llama-2-7b-chat-hf", use_auth_token=True)


finetune_model=PeftModel.from_pretrained(model,"smangrul/llama-ad-gen") 

prompt = "<s>[INST] <<SYS>>\nCreate a text ad given the following product and description.\n<</SYS>>\n\nProduct: Sony PS5 PlayStation Console\nDescription: The PS5™ console unleashes new gaming possibilities that you never anticipated. [/INST]"
outputs = model.generate(input_ids=tokenizer(prompt, return_tensors="pt").input_ids.cuda(), 
                                 max_new_tokens=1024,
                                 temperature=0.2,
                                 top_k=50,
                                 top_p=0.95,
                                 do_sample=True,
                                 repetition_penalty=1.2,
                                 eos_token_id = tokenizer.eos_token_id)

print(tokenizer.batch_decode(outputs, skip_special_tokens=False)[0])
```

Error without it:
```
KeyError: 'base_model.model.model.layers.0.self_attn.q_proj.base_layer.weight'
```

Output with this PR:
```
<s><s> [INST] <<SYS>>
Create a text ad given the following product and description.
<</SYS>>

Product: Sony PS5 PlayStation Console
Description: The PS5™ console unleashes new gaming possibilities that you never anticipated. [/INST] Ad: Unlock endless fun with PS5! 🎮🌟 Experience stunning graphics, immersive gameplay, and groundbreaking features. Perfect for gamers of all levels. Limited stock - level up your gaming experience! 🌟👾🚀 </s>
```