### PR TITLE
[`core`] Fix 4bit serialization issues in case keys not present in state dict (e.g. when loading adapter weights through `PEFT`)

### DIFF
--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -261,7 +261,7 @@ class Linear4bit(nn.Linear):
             self.weight, state_dict = bnb.nn.Params4bit.from_state_dict(
                 state_dict, prefix=prefix, requires_grad=False
             )
-            unexpected_keys.extend(state_dict.keys())
+        unexpected_keys.extend(state_dict.keys())
 
     def forward(self, x: torch.Tensor):
         # weights are cast automatically as Int8Params, but the bias has to be cast manually

--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -257,7 +257,7 @@ class Linear4bit(nn.Linear):
         # If not, we assume that the state_dict does contain some keys 
         # that are not present in the model
         prefix = prefix + "weight" + "."
-        if prefix.rstrip('.') in set(state_dict.keys()):
+        if prefix.rstrip('.') in state_dict:
             self.weight, state_dict = bnb.nn.Params4bit.from_state_dict(
                 state_dict, prefix=prefix, requires_grad=False
             )

--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -257,7 +257,7 @@ class Linear4bit(nn.Linear):
         # If not, we assume that the state_dict does contain some keys 
         # that are not present in the model
         prefix = prefix + "weight" + "."
-        if prefix in set(state_dict.keys()):
+        if prefix.rstrip('.') in set(state_dict.keys()):
             self.weight, state_dict = bnb.nn.Params4bit.from_state_dict(
                 state_dict, prefix=prefix, requires_grad=False
             )


### PR DESCRIPTION
# What does this PR do?

Fixes: https://github.com/huggingface/peft/issues/1095 and other issues related with QLoRA and adapter loading / saving utilities

This PR fixes two things that were supported in previous bnb versions:

1- Loading a QLoRA adapter weight with bias terms in the Linear layer
2- Loading adapter weights on a quantized base model.

`model.load_state_dict` will recursively call `_load_from_state_dict` method on each submodule of the model. That method for 4bit layers has been very recently introduced in this commit: https://github.com/TimDettmers/bitsandbytes/commit/76b40a5c9ae708db98e8b4a13249b2806601a387 

1)

```python
bias_data = state_dict.pop(prefix + "bias", None)
```

Might pop `None` therefore for linear layers with bias terms **and** when loading adapter weights.
The line `self.bias.data = bias_data.to(self.bias.data.device)` will fail - this can be reproduced with the snippet below that load an OPT model which contains bias terms on Linear layers. 

2)

Relatively similar issue there since `from_state_dict` calls `pop()` it can return `None` in case there is not the corresponding key in the state dict, again this is applicable only when loading adapter weights. The fix is also straightfoward, simply protect the call to `from_state_dict` by checking if  `prefix.rstrip('.')` is inside `set(state_dict.keys())`.

## Reproduction

To reproduce, simply run:

```python
import tempfile
import torch
from peft import AutoPeftModelForCausalLM


model = AutoPeftModelForCausalLM.from_pretrained("peft-internal-testing/tiny-OPTForCausalLM-lora", load_in_4bit=True)

with tempfile.TemporaryDirectory() as tmp_dir:
    model.save_pretrained(tmp_dir)
    model = AutoPeftModelForCausalLM.from_pretrained(tmp_dir, load_in_4bit=True)

    dummy_input = torch.LongTensor([[0, 1, 0]])
    out = model.generate(input_ids=dummy_input)
```

cc @poedator @TimDettmers @Titus-von-Koeller 