### PR TITLE
fixes to recent PR #753

### DIFF
--- a/bitsandbytes/functional.py
+++ b/bitsandbytes/functional.py
@@ -567,6 +567,7 @@ def estimate_quantiles(A: Tensor, out: Tensor = None, offset: float = 1 / 512, n
 
     return out
 
+
 class QuantState:
     """container for quantization state components to work with Params4bit and similar clases"""
     valid_quant_types = ('fp4', 'nf4')
@@ -574,7 +575,6 @@ class QuantState:
     valid_qs_keys = ['absmax', 'quant_map', 'nested_absmax', 'nested_quant_map', 'quant_state', 
                      'quant_type', 'blocksize', 'dtype', 'shape', 'nested_blocksize', 'nested_dtype', 'nested_offset']
 
-    
     def __init__(self, absmax, shape=None, code=None, blocksize=None, quant_type=None, dtype=None, offset=None, state2=None):
         self.absmax = absmax
         self.shape = shape
@@ -585,7 +585,7 @@ class QuantState:
         self.offset = offset
         self.state2 = state2
         self.nested = state2 is not None
-        
+
     def __get_item__(self, idx):
         """
         ensures compatibility with older quant state scheme with nested lists.
@@ -598,7 +598,7 @@ class QuantState:
         else:
             list_repr = [self.absmax, self.shape, self.dtype, self.blocksize, None, self.quant_type]
         return list_repr[idx]
-    
+
     @classmethod
     def from_dict(cls, qs_dict: Dict[str, Any], device: torch.device) -> 'QuantState':
         """
@@ -606,7 +606,7 @@ class QuantState:
         where necessary, convert into strings, torch.dtype, ints, etc.
 
         qs_dict: based on state_dict, with only relevant keys, striped of prefixes.
-         
+
         item with key `quant_state.bitsandbytes__[nf4/fp4]` may contain minor and non-tensor quant state items.        
         """
 
@@ -615,8 +615,8 @@ class QuantState:
         if not len(qs_key) and 'quant_type' not in qs_dict:
             raise ValueError("Expected packed or unpacked quant_state items, found neither") 
         elif len(qs_key) != 1:
-            raise ValueError(f"There should be exaclly one quant_state item with key from {self.valid_qs_type_keys}. Detected {len(qs_ley)} such items")
-        
+            raise ValueError(f"There should be exaclly one quant_state item with key from {cls.valid_qs_type_keys}. Detected {len(qs_key)} such items")
+
         # unpacking minor and non-tensor quant state items if necessary
         if len(qs_key) == 1:
             qs_key = qs_key[0]
@@ -673,7 +673,7 @@ class QuantState:
         non_tensor_dict = {k: v for k, v in qs_dict.items() if not isinstance(v, torch.Tensor)}
         qs_packed_dict["quant_state." + "bitsandbytes__" + self.quant_type] = pack_dict_to_tensor(non_tensor_dict)
         return qs_packed_dict
-                    
+
     def to(self, device):
         # make sure the quantization state is on the right device
         self.absmax = self.absmax.to(device)
@@ -681,6 +681,7 @@ class QuantState:
             self.offset = self.offset.to(device)
             self.state2.absmax = self.state2.absmax.to(device)
             self.state2.code = self.state2.code.to(device)
+
 
 def quantize_blockwise(A: Tensor, code: Tensor = None, absmax: Tensor = None, out: Tensor = None, blocksize=4096, nested=False) -> Tensor:
     """

--- a/bitsandbytes/functional.py
+++ b/bitsandbytes/functional.py
@@ -680,7 +680,6 @@ class QuantState:
     def to(self, device):
         # make sure the quantization state is on the right device
         self.absmax = self.absmax.to(device)
-        self.offset = self.offset.to(device)
         if self.nested:
             self.offset = self.offset.to(device)
             self.state2.absmax = self.state2.absmax.to(device)

--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -155,28 +155,38 @@ class Params4bit(torch.nn.Parameter):
         return self
 
     @classmethod
-    def from_state_dict(cls, state_dict, prefix="", requires_grad=False):
-        data = state_dict.pop(prefix.rstrip('.'))
+    def from_prequantized(cls, data, quantized_stats, requires_grad=False, device='cuda', **kwargs):
+        self = torch.Tensor._make_subclass(cls, data.to(device))
+        self.requires_grad = requires_grad
+        self.quant_state = QuantState.from_dict(qs_dict=quantized_stats, device=device)
+        self.blocksize = self.quant_state.blocksize
+        self.compress_statistics = self.quant_state.nested
+        self.quant_type = self.quant_state.quant_type
+        return self
+    
+    # @classmethod
+    # def from_state_dict(cls, state_dict, prefix="", requires_grad=False):
+    #     data = state_dict.pop(prefix.rstrip('.'))
 
-        # extracting components for QuantState from state_dict
-        qs_dict = {}
-        for k, v in state_dict.items():
-            if k.replace(prefix, '').split('.')[0] in QuantState.valid_qs_keys:
-                qs_dict[k] = v        
-        state_dict = {k: v for k, v in state_dict.items() if k not in qs_dict}
-        qs_dict = {k.replace(prefix, ''): v for k, v in qs_dict.items()}
+    #     # extracting components for QuantState from state_dict
+    #     qs_dict = {}
+    #     for k, v in state_dict.items():
+    #         if k.replace(prefix, '').split('.')[0] in QuantState.valid_qs_keys:
+    #             qs_dict[k] = v        
+    #     state_dict = {k: v for k, v in state_dict.items() if k not in qs_dict}
+    #     qs_dict = {k.replace(prefix, ''): v for k, v in qs_dict.items()}
 
-        if data.device.type != "cuda":
-            raise ValueError(f"`data.device.type` must be 'cuda', detected {data.device.type}")
+    #     if data.device.type != "cuda":
+    #         raise ValueError(f"`data.device.type` must be 'cuda', detected {data.device.type}")
 
-        cls.requires_grad = requires_grad
-        cls.quant_state = QuantState.from_dict(qs_dict=qs_dict, device=data.device)
-        cls.blocksize = cls.quant_state.blocksize             # this attribute can be deprecated - it duplicates same one in quant_state
-        cls.compress_statistics = cls.quant_state.nested      # this attribute can be deprecated - it duplicates quant_state.nested
-        cls.quant_type = cls.quant_state.quant_type           # this attribute can be deprecated - it duplicates same one in quant_state
+    #     cls.requires_grad = requires_grad
+    #     cls.quant_state = QuantState.from_dict(qs_dict=qs_dict, device=data.device)
+    #     cls.blocksize = cls.quant_state.blocksize             # this attribute can be deprecated - it duplicates same one in quant_state
+    #     cls.compress_statistics = cls.quant_state.nested      # this attribute can be deprecated - it duplicates quant_state.nested
+    #     cls.quant_type = cls.quant_state.quant_type           # this attribute can be deprecated - it duplicates same one in quant_state
 
-        self = torch.Tensor._make_subclass(cls, data=data.to(data.device))
-        return self, state_dict
+    #     self = torch.Tensor._make_subclass(cls, data=data.to(data.device))
+    #     return self, state_dict
 
     def cuda(self, device):
         w = self.data.contiguous().half().cuda(device)
@@ -251,17 +261,17 @@ class Linear4bit(nn.Linear):
             for k, v in self.weight.quant_state.as_dict(packed=True).items():
                 destination[prefix + "weight." + k] = v if keep_vars else v.detach()
 
-    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
-                              missing_keys, unexpected_keys, error_msgs):
-        # Note: super()._load_from_state_dict() is not called here intentionally.
-        if self.bias is not None:
-            bias_data = state_dict.pop(prefix + "bias", None)
-            self.bias.data = bias_data.to(self.bias.data.device)
+    # def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
+    #                           missing_keys, unexpected_keys, error_msgs):
+    #     # Note: super()._load_from_state_dict() is not called here intentionally.
+    #     if self.bias is not None:
+    #         bias_data = state_dict.pop(prefix + "bias", None)
+    #         self.bias.data = bias_data.to(self.bias.data.device)
 
-        self.weight, state_dict = bnb.nn.Params4bit.from_state_dict(
-                        state_dict, prefix=prefix + "weight" + ".", requires_grad=False
-                    )
-        unexpected_keys.extend(state_dict.keys())
+    #     self.weight, state_dict = bnb.nn.Params4bit.from_state_dict(
+    #                     state_dict, prefix=prefix + "weight" + ".", requires_grad=False
+    #                 )
+    #     unexpected_keys.extend(state_dict.keys())
 
     def forward(self, x: torch.Tensor):
         # weights are cast automatically as Int8Params, but the bias has to be cast manually

--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -2,7 +2,7 @@
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
-from typing import Optional, TypeVar, Union, overload
+from typing import Any, Dict, Optional, TypeVar, Union, overload
 
 import warnings
 import torch
@@ -142,7 +142,7 @@ class Embedding(torch.nn.Embedding):
 
 class Params4bit(torch.nn.Parameter):
 
-    def __new__(cls, data=None, requires_grad=True, quant_state=None, blocksize=64, compress_statistics=True, quant_type='fp4'):
+    def __new__(cls, data: Optional[torch.Tensor] = None, requires_grad=True, quant_state: QuantState = None, blocksize: int = 64, compress_statistics: bool = True, quant_type: str = 'fp4') -> "Params4bit":
         if data is None:
             data = torch.empty(0)
 
@@ -155,7 +155,7 @@ class Params4bit(torch.nn.Parameter):
         return self
 
     @classmethod
-    def from_prequantized(cls, data, quantized_stats, requires_grad=False, device='cuda', **kwargs):
+    def from_prequantized(cls, data: torch.Tensor, quantized_stats: Dict[str, Any], requires_grad: bool = False, device='cuda', **kwargs) -> "Params4bit":
         self = torch.Tensor._make_subclass(cls, data.to(device))
         self.requires_grad = requires_grad
         self.quant_state = QuantState.from_dict(qs_dict=quantized_stats, device=device)

--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -168,8 +168,11 @@ class Params4bit(torch.nn.Parameter):
         if data.device.type != "cuda":
             raise ValueError(f"`data.device.type` must be 'cuda', detected {data.device.type}")
 
-        cls.requires_grad = requires_grad,
+        cls.requires_grad = requires_grad
         cls.quant_state = QuantState.from_dict(qs_dict=qs_dict, device=data.device)
+        cls.blocksize = cls.quant_state.blocksize
+        cls.compress_statistics = cls.quant_state.nested
+        cls.quant_type = cls.quant_state.quant_type
 
         self = torch.Tensor._make_subclass(cls, data=data.to(data.device))
         return self, state_dict


### PR DESCRIPTION
Save and load in NF4 / FP4 formats 
This fixes problems arising from my recent pull request #753 , mainly coming from [this commit](https://github.com/TimDettmers/bitsandbytes/pull/753/commits/76b40a5c9ae708db98e8b4a13249b2806601a387): 

1) The idea to override `_load_from_state_dict` for `Linear4bit` looked very elegant, with a view to simplify Transformers integration. However it has more sensitivities than I expected including one with `peft`.

2) replaced `|=` operator with `.update()` to keep compatibility with Python 3.8

this should fix https://github.com/huggingface/peft/issues/1095

@TimDettmers @Titus-von-Koeller please review.
