### PR TITLE
Update env_vars.py to include GOOGLE_VM_CONFIG_LOCK_FILE

### DIFF
--- a/bitsandbytes/cuda_setup/env_vars.py
+++ b/bitsandbytes/cuda_setup/env_vars.py
@@ -8,6 +8,7 @@ def to_be_ignored(env_var: str, value: str) -> bool:
         "OLDPWD",
         "SSH_AUTH_SOCK",  # SSH stuff, therefore unrelated
         "SSH_TTY",
+        "GOOGLE_VM_CONFIG_LOCK_FILE",  # on GCP setups, requires elevated permissions, causing problems in Jupyter notebooks
         "HOME",  # Linux shell default
         "TMUX",  # Terminal Multiplexer
         "XDG_DATA_DIRS",  # XDG: Desktop environment stuff


### PR DESCRIPTION
See this comment: https://github.com/TimDettmers/bitsandbytes/issues/620#issuecomment-1666014197

adding this variable to be ignored allows the bitsandbytes import and setup to proceed on a GCP VM in a jupyter notebook.