### PR TITLE
Fix issue #901: Failing PEFT integration tests by reversing PR#867 from jph00/patch-2

### DIFF
--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -165,8 +165,6 @@ class Params4bit(torch.nn.Parameter):
         return self
 
     def cuda(self, device):
-        if self.quant_state is not None:
-            return self
         w = self.data.contiguous().half().cuda(device)
         w_4bit, quant_state = bnb.functional.quantize_4bit(w, blocksize=self.blocksize, compress_statistics=self.compress_statistics, quant_type=self.quant_type)
         self.data = w_4bit


### PR DESCRIPTION
Revert "Merge PR#867 from jph00/patch-2" due to failing PEFT integration tests.

This reverts commit 2ee289fb2f0c4f8e02c974be4a46377a5e94bddf, reversing changes made to 744d36f7b0f42861bb90a698faf4431987af3b23.