### PR TITLE
fix array index out of bounds in kgetColRowStats

### DIFF
--- a/csrc/kernels.cu
+++ b/csrc/kernels.cu
@@ -2178,7 +2178,12 @@ template<typename T, int THREADS, int ITEMS_PER_THREAD, int TILE_ROWS, int TILE_
   {
     //smem_col_absmax_values[threadIdx.x + (j*THREADS)] = -FLT_MAX;
     smem_row_absmax_values[threadIdx.x + (j*THREADS)] = -FLT_MAX;
-    smem_row_nnz_values[threadIdx.x + (j*THREADS)] = 0;
+    // smem_row_nnz_values[threadIdx.x + (j*THREADS)] = 0;
+  }
+
+  #pragma unroll TILE_ROWS
+  for (int j = 0; j < TILE_ROWS; j++) {
+    smem_row_nnz_values[j] = 0;
   }
 
   #pragma unroll ITEMS_PER_THREAD


### PR DESCRIPTION
the code of kgetColRowStats() kernel:
```
template<typename T, int THREADS, int ITEMS_PER_THREAD, int TILE_ROWS, int TILE_COLS, int SPARSE_DECOMP> __global__ void kgetColRowStats(T * __restrict__ A, float *rowStats, float *colStats, int * nnz_count_row, float nnz_threshold, int rows, int cols, int tiledRows, int tiledCols)
{
  ...
  __shared__ int smem_row_nnz_values[TILE_ROWS]; 
  ...
  // 0. reset stats to -FLT_MAX
  for(int j = 0; j < ITEMS_PER_THREAD; j++)
  {
    //smem_col_absmax_values[threadIdx.x + (j*THREADS)] = -FLT_MAX;
    smem_row_absmax_values[threadIdx.x + (j*THREADS)] = -FLT_MAX; 
    smem_row_nnz_values[threadIdx.x + (j*THREADS)] = 0;                     <----
  }
}
```

the following is call the kgetColRowStats() kernel:

```
template __global__ void kgetColRowStats<half, 64, 4, 16, 64*4, 0>(half * __restrict__ A, float *rowStats, float *colStats, int * nnz_count_row, float nnz_threshold, int rows, int cols, int tiledRows, int tiledCols);
template __global__ void kgetColRowStats<half, 64, 4, 16, 64*4, 1>(half * __restrict__ A, float *rowStats, float *colStats, int * nnz_count_row, float nnz_threshold, int rows, int cols, int tiledRows, int tiledCols);

```

so TILE_ROWS=16, the number of threads for per block is 64, this cause an out-of-bounds error
