### PR TITLE
Move to CPU before attempting to convert to numpy.

### DIFF
--- a/bitsandbytes/utils.py
+++ b/bitsandbytes/utils.py
@@ -187,7 +187,7 @@ def unpack_tensor_to_dict(tensor_data):
     Returns:
     A Python dictionary containing the unpacked data.
     """
-    json_bytes = bytes(tensor_data.numpy())
+    json_bytes = bytes(tensor_data.cpu().numpy())
     json_str = json_bytes.decode('utf-8')
     unpacked_dict = json.loads(json_str)
 


### PR DESCRIPTION
I ran into this when loading from 4bit in Transformers while everything was loaded in a `with torch.device("cuda"):` context. I know that functionality isn't fully merged yet in Transformers but I had been using it last night in a separate fork after rebasing and installing the work from https://github.com/huggingface/transformers/pull/26037.

I ran the test suite and there are a few (4) failures that I'm not certain would be caused by my code such as an issue with the triton jit.