### PR TITLE
Fix `max_memory` example on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ model = AutoModelForCausalLM.from_pretrained(
   'decapoda-research/llama-7b-hf,
   device_map='auto',
   load_in_8bit=True,
-  max_memory=f'{int(torch.cuda.mem_get_info()[0]/1024**3)-2}GB')
+  max_memory={
+    i: f'{int(torch.cuda.mem_get_info(i)[0]/1024**3)-2}GB'
+    for i in range(torch.cuda.device_count())
+  }
+)
 ```
 
 A more detailed example, can be found in [examples/int8_inference_huggingface.py](examples/int8_inference_huggingface.py).

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ python setup.py install
 ```python
 from transformers import AutoModelForCausalLM
 model = AutoModelForCausalLM.from_pretrained(
-  'decapoda-research/llama-7b-hf,
+  'decapoda-research/llama-7b-hf',
   device_map='auto',
   load_in_8bit=True,
   max_memory={


### PR DESCRIPTION
Running the current README example on `max_memory` results in this strange error:

```python
File ~/miniforge3/envs/llms/lib/python3.9/site-packages/accelerate/utils/modeling.py:807, in get_balanced_memory(model, max_memory, no_split_module_classes, dtype, special_dtypes, low_zero)
    805 # Get default / clean up max_memory
    806 user_not_set_max_memory = max_memory is None
--> 807 max_memory = get_max_memory(max_memory)
    809 if not is_xpu_available():
    810     num_devices = len([d for d in max_memory if torch.device(d).type == "cuda" and max_memory[d] > 0])

File ~/miniforge3/envs/llms/lib/python3.9/site-packages/accelerate/utils/modeling.py:693, in get_max_memory(max_memory)
    690     return max_memory
    692 for key in max_memory:
--> 693     if isinstance(max_memory[key], str):
    694         max_memory[key] = convert_file_size_to_int(max_memory[key])
    696 # Need to sort the device by type to make sure that we allocate the gpu first.
    697 # As gpu/xpu are represented by int, we need to sort them first.

TypeError: string indices must be integers
```

This is because the new `max_memory` syntax in accelerate expects a dictionary: https://huggingface.co/docs/accelerate/v0.25.0/en/concept_guides/big_model_inference#designing-a-device-map.

This PR also:

- Updates the README example to account for multiple devices
- Fixes the model name not being enclosed in matching quotes