### PR TITLE
Fix bug: when moving quantized model between CPU and GPU, the 4bit weights gets re-quantized

### DIFF
--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -165,6 +165,11 @@ class Params4bit(torch.nn.Parameter):
         return self
 
     def cuda(self, device):
+        if self.quant_state is not None:
+            if self.data.device != device:
+                self.data = self.data.to(device)
+                self.quant_state.to(device)
+            return self
         w = self.data.contiguous().half().cuda(device)
         w_4bit, quant_state = bnb.functional.quantize_4bit(w, blocksize=self.blocksize, compress_statistics=self.compress_statistics, quant_type=self.quant_type)
         self.data = w_4bit


### PR DESCRIPTION
when moving quantized model between CPU and GPU, the 4bit weights gets re-quantized, this issue is reported #937 

The purposed code add a condition check and only apply the quantization if no quant_state exists.

The full test code can be found in this Colab notebook:
https://colab.research.google.com/drive/1rBWjA5VsWdTE6GiATJWHFKHbdt-HrHE4?usp=sharing
