### PR TITLE
Quote folder and filename in find_file_recursive

### DIFF
--- a/bitsandbytes/__main__.py
+++ b/bitsandbytes/__main__.py
@@ -31,6 +31,8 @@ def execute_and_return(command_string: str) -> Tuple[str, str]:
     return std_out, std_err
 
 def find_file_recursive(folder, filename):
+    folder = shlex.quote(folder)
+    filename = shlex.quote(filename)
     cmd = f'find {folder} -name {filename}'
     out, err = execute_and_return(cmd)
     if len(err) > 0:
@@ -151,4 +153,3 @@ except Exception as e:
     print(e)
     print_debug_info()
     sys.exit(1)
-


### PR DESCRIPTION
Hello,

As of now, `python -m bitsandbytes` doesn't work if there's a space in `os.getcwd()`, because `find` then treats the path as multiple arguments. So `find_file_recursive` fails with a confusing "Maybe you do not have a linux system" error.

This is fixed by shell quoting the arguments.