### PR TITLE
Fix `keyword argument repeated` in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
     license="MIT",
     keywords="gpu optimizers optimization 8-bit quantization compression",
     url="https://github.com/TimDettmers/bitsandbytes",
-    install_requires=['scipy'],
     packages=find_packages(),
     package_data={"": libs},
     install_requires=['torch', 'numpy', 'scipy'],


### PR DESCRIPTION
`setup.py` mention `install_requires` twice (likely a typo). 

```
root@56e1be9f59d2:/bitsandbytes# python3 setup.py install
  File "setup.py", line 32
    install_requires=['torch', 'numpy', 'scipy'],
    ^
SyntaxError: keyword argument repeated
```

This removes the first mention (already covered by the latter one).