### PR TITLE
Add .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,8 @@
+# ran black and isort for coherent code formatting
+bfa0e33294f2b1dc25e65a33be2397f989824298
+
+# reran black with linelength 80 for greater readability
+ea7c14f8ef64924f2d0ff80df3cdabf2c7299848
+
+# Remove f-prefix from strings that don't use formatting
+7727fa4c8c6c1ef2b109120aff4196a0a6bf3ed6


### PR DESCRIPTION
This PR adds a [.git-blame-ignore-revs](https://github.blog/changelog/2022-03-24-ignore-commits-in-the-blame-view-beta) to make it easier to find relevant information in `git blame` views, as commits that only refactor code will be ignored there.