### PR TITLE
Create upload_pr_documentation.yml

### DIFF
--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@main
     with:
-      package_name: peft
+      package_name: bitsandbytes
     secrets:
       hf_token: ${{ secrets.HUGGINGFACE_PUSH }}
       comment_bot_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -1,0 +1,16 @@
+name: Upload PR Documentation
+
+on:
+  workflow_run:
+    workflows: ["Build PR Documentation"]
+    types:
+      - completed
+
+jobs:
+  build:
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@main
+    with:
+      package_name: peft
+    secrets:
+      hf_token: ${{ secrets.HUGGINGFACE_PUSH }}
+      comment_bot_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
secrets.GITHUB_TOKEN is an automated token that should work fine for all GH repos, this should hopefully upload the PR documentation 

https://docs.github.com/en/actions/security-guides/automatic-token-authentication

cc @Titus-von-Koeller 