### PR TITLE
Tweak/optimize Cmake build slightly

### DIFF
--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -9,6 +9,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository == 'TimDettmers/bitsandbytes'
     uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@main
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ "main" ]
 
+concurrency:
+  group: cmake-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -148,12 +148,6 @@ jobs:
     - name: Build CPU
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
 
-    - name: Test
-      working-directory: ${{ steps.strings.outputs.build-output-dir }}
-      # Execute tests defined by the CMake configuration. Note that --build-config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
-      # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-      run: ctest --build-config ${{ matrix.build_type }}
-
     - name: Build dist
       shell: bash -el {0}
       run: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,19 +23,6 @@ jobs:
         python-version: ['3.10', '3.11']
         cuda-version: ['11.8', '12.1']
         build_type: [Release]
-        c_compiler: [gcc, cl]
-        include:
-          - os: windows-latest
-            c_compiler: cl
-            cpp_compiler: cl
-          - os: ubuntu-latest
-            c_compiler: gcc
-            cpp_compiler: g++
-        exclude:
-          - os: ubuntu-latest
-            c_compiler: cl
-          - os: windows-latest
-            c_compiler: gcc
 
     steps:
     - uses: actions/checkout@v4
@@ -101,8 +88,13 @@ jobs:
         echo CUDA_PATH=$CUDA_HOME >> "$GITHUB_ENV"
 
         if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            echo CXX_COMPILER=cl >> "$GITHUB_ENV"
+            echo C_COMPILER=cl >> "$GITHUB_ENV"
             # without -DCMAKE_CUDA_COMPILER=nvcc, cmake config always fail for cuda-11.8
             echo DCMAKE_CUDA_COMPILER=-DCMAKE_CUDA_COMPILER=nvcc >> "$GITHUB_ENV"
+        else
+            echo CXX_COMPILER=g++ >> "$GITHUB_ENV"
+            echo C_COMPILER=gcc >> "$GITHUB_ENV"
         fi
 
         nvcc --version
@@ -113,26 +105,27 @@ jobs:
     - name: Prep build
       run: python -m pip install cmake==3.27.9 ninja setuptools wheel
 
-    - name: Configure CMake
+    # TODO: the following steps (CUDA, NOBLASLT, CPU) could be moved to the matrix, so they're built in parallel
+
+    - name: Configure CUDA
       run: >
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
         -G Ninja ${{ env.DCMAKE_CUDA_COMPILER }}
-        -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
-        -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
+        -DCMAKE_CXX_COMPILER=${{ env.CXX_COMPILER }}
+        -DCMAKE_C_COMPILER=${{ env.C_COMPILER }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -DCOMPUTE_CAPABILITY="50;52;60;61;62;70;72;75;80;86;87;89;90"
         -S ${{ github.workspace }}
 
-    - name: Build
-      # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
+    - name: Build CUDA
       run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
 
     - name: Configure NOBLASLT
       run: >
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
         -G Ninja ${{ env.DCMAKE_CUDA_COMPILER }}
-        -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
-        -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
+        -DCMAKE_CXX_COMPILER=${{ env.CXX_COMPILER }}
+        -DCMAKE_C_COMPILER=${{ env.C_COMPILER }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -DCOMPUTE_CAPABILITY="50;52;60;61;62;70;72;75;80;86;87;89;90"
         -DNO_CUBLASLT=ON
@@ -145,8 +138,8 @@ jobs:
       run: >
         cmake -B ${{ steps.strings.outputs.build-output-dir }}
         -G Ninja ${{ env.DCMAKE_CUDA_COMPILER }}
-        -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
-        -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
+        -DCMAKE_CXX_COMPILER=${{ env.CXX_COMPILER }}
+        -DCMAKE_C_COMPILER=${{ env.C_COMPILER }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
         -DNO_CUBLASLT=ON
         -DBUILD_CUDA=OFF

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -20,16 +20,11 @@ jobs:
 
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.10', '3.11']
         cuda-version: ['11.8', '12.1']
         build_type: [Release]
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
-      with:
-        python-version: ${{ matrix.python-version }}
 
     - name: Set up MSVC
       if: matrix.os == 'windows-latest'
@@ -52,7 +47,7 @@ jobs:
         environment-file: environment-bnb.yml
         use-only-tar-bz2: false
         auto-activate-base: true
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.10"
         mamba-version: "*"
 
     - name: Set reusable strings
@@ -159,6 +154,6 @@ jobs:
     - name: Upload Build Artifacts
       uses: actions/upload-artifact@v4.3.0
       with:
-        name: bitsandbytes-${{ matrix.os }}-${{ matrix.python-version }}-${{ matrix.cuda-version }}
+        name: bitsandbytes-${{ matrix.os }}-${{ matrix.cuda-version }}
         path: |
           ${{ github.workspace }}/dist/


### PR DESCRIPTION
This follows up on #908 to make it do less work and simplify things some.

Since we don't actually link against the Python ABI, we only need to build on Python 3.10. CPython 3.10 _and newer_ should happily accept a `cp310` wheel:

```
$ docker run -it --platform=linux/amd64 python:3.12 sh -c 'pip debug --verbose | grep cp310'
[...]
  cp310-abi3-manylinux1_x86_64
  cp310-abi3-linux_x86_64
```

(#1010 discusses being able to force the wheel tag, so we could build on a newer, faster Python, but still get a cp310 wheel.)