### PR TITLE
minimal macos support

### DIFF
--- a/bitsandbytes/cuda_setup/main.py
+++ b/bitsandbytes/cuda_setup/main.py
@@ -37,7 +37,7 @@ else:  # Linux or other
     # we have libcudart.so.11.0 which causes a lot of errors before
     # not sure if libcudart.so.12.0 exists in pytorch installs, but it does not hurt
     CUDA_RUNTIME_LIBS = ["libcudart.so", "libcudart.so.11.0", "libcudart.so.12.0", "libcudart.so.12.1", "libcudart.so.12.2"]
-    DYNAMIC_LIBRARY_SUFFIX = ".so"
+    DYNAMIC_LIBRARY_SUFFIX = { "Darwin": ".dylib", "Windows":".dll" }.get(platform.system(), ".so")
 
 
 class CUDASetup:


### PR DESCRIPTION
This is a PR to support macos based on @rickardp's work (PR #949 )
for those who want to use bitsandbytes under OSX with minimal support.

 * original work done by @niclimcy and @rickardp
 * [x] ~~macos cpu module support~~
 * [x] load `libbitsandbytes_cpu.dylib` correctly.