### PR TITLE
[Portability] Add build artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,9 @@ bitsandbytes.dir/
 Debug/
 Release/
 
+# IDE local files
+.vs/
+
 # Distribution / packaging
 .Python
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,26 @@
 __pycache__/
 *.py[cod]
 *$py.class
-
-# C extensions
 *.so
+*.dll
+*.dylib
+*.o
+*.obj
+*.air
+*.metallib
+
+# CMake generated files
+CMakeCache.txt
+CMakeScripts/
+cmake_install.cmake
+Makefile
+CMakeFiles/
+*.sln
+*.vcxproj*
+*.xcodeproj/
+bitsandbytes.dir/
+Debug/
+Release/
 
 # Distribution / packaging
 .Python
@@ -133,4 +150,5 @@ dmypy.json
 
 dependencies
 cuda_build
+output/
 .vscode/*


### PR DESCRIPTION
Code change broken out from PR https://github.com/TimDettmers/bitsandbytes/pull/949 to keep this change separate from the portability/pipelines in that PR.

Currently running cmake produces changes to version controlled files. This PR adds build output and cmake cache files to .gitignore.

