### PR TITLE
docs: fix broken links

### DIFF
--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -8,8 +8,8 @@ There are ongoing efforts to support further hardware backends, i.e. Intel CPU +
 
 ## API documentation
 
-- [Linear4bit](quantizaton#linear4bit)
-- [Linear8bit](quantizaton#linear8bit)
+- [Linear4bit](quantization#linear4bit)
+- [Linear8bit](quantization#linear8bit)
 - [StableEmbedding](optimizers#stableembedding)
 
 # License

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -8,9 +8,9 @@ There are ongoing efforts to support further hardware backends, i.e. Intel CPU +
 
 ## API documentation
 
-- [Linear4bit](quantization#linear4bit)
-- [Linear8bit](quantization#linear8bit)
-- [StableEmbedding](optimizers#stableembedding)
+- [Quantization](quantization)
+- [Integrations](integrations)
+- [Optimizers](optimizers)
 
 # License
 

--- a/docs/source/optimizers.mdx
+++ b/docs/source/optimizers.mdx
@@ -184,7 +184,7 @@ class MyModule(torch.nn.Module):
 
 Here we'll provide further auto-generated API docs soon. Please feel free to contribute doc-strings for the respective optimizers, as `bitsandbytes` is a community effort.
 
-## StableEmbedding
+### StableEmbedding[[stable-emb-api]]
 
 [[autodoc]] bitsandbytes.nn.StableEmbedding
     - __init__


### PR DESCRIPTION
The quant classes links on the index page currently give a 404.