### PR TITLE
Add concurrency lock to Python wheel workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,9 +15,12 @@ on:
       - 'setup.py'
       - 'pyproject.toml'
       - 'pytest.ini'
-      - '**/*.md'
   release:
     types: [ published ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
 


### PR DESCRIPTION
To not waste precious build minutes when modifying PRs frequently.

As added in #1035 

Also fixes an unnecessary path filter, but possibly it would be better to turn the filter around later.