### PR TITLE
CI: Fix cuda toolkit speed issue.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -102,7 +102,7 @@ jobs:
       id: cuda-toolkit
       with:
         cuda: ${{ matrix.cuda_version }}
-        method: 'local'
+        method: 'network'
         sub-packages: '["nvcc","cudart","cusparse","cublas","thrust","nvrtc_dev","cublas_dev","cusparse_dev"]'
         linux-local-args: '["--toolkit"]'
         use-github-cache: false
@@ -117,6 +117,7 @@ jobs:
         set -ex
         build_os=${{ matrix.os }}
         build_arch=${{ matrix.arch }}
+        [[ "${{ matrix.os }}" = windows-* ]] && python3 -m pip install ninja
         for NO_CUBLASLT in ON OFF; do
           if [ ${build_os:0:6} == ubuntu ]; then
             image=nvidia/cuda:${{ matrix.cuda_version }}-devel-ubuntu22.04
@@ -127,7 +128,6 @@ jobs:
               && cmake -DCOMPUTE_BACKEND=cuda -DNO_CUBLASLT=${NO_CUBLASLT} . \
               && cmake --build ."
           else
-            python3 -m pip install cmake==3.27.9 ninja
             cmake -G Ninja -DCOMPUTE_BACKEND=cuda -DNO_CUBLASLT=${NO_CUBLASLT} -DCMAKE_BUILD_TYPE=Release -S .
             cmake --build . --config Release
           fi

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -106,7 +106,9 @@ jobs:
       with:
         cuda: ${{ matrix.cuda_version }}
         method: 'local'
-        # sub-packages: '["nvcc","cudart","nvrtc_dev","cublas_dev","cusparse_dev","visual_studio_integration"]'
+        sub-packages: '["nvcc","cudart","cusparse","cublas","thrust","nvrtc_dev","cublas_dev","cusparse_dev"]'
+        linux-local-args: '["--toolkit"]'
+        use-github-cache: false
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v1.1
       if: ${{ startsWith(matrix.os, 'windows') }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -41,9 +41,10 @@ jobs:
       uses: jwlawson/actions-setup-cmake@v1.14
       with:
         cmake-version: '3.26.x'
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.1
-      if: ${{ startsWith(matrix.os, 'windows') }}
+    - name: Setup MSVC
+      if: startsWith(matrix.os, 'windows')
+      #uses: microsoft/setup-msbuild@v1.1 # to use msbuild
+      uses: ilammy/msvc-dev-cmd@v1.13.0 # to use cl
       # Compile C++ code
     - name: Build C++
       shell: bash
@@ -60,11 +61,7 @@ jobs:
         else
           cmake -DCOMPUTE_BACKEND=cpu .
         fi
-        if [ ${build_os:0:7} == windows ]; then
-          pwsh -Command "msbuild bitsandbytes.vcxproj /property:Configuration=Release"
-        else
-          make
-        fi
+        cmake --build . --config Release
         mkdir -p output/${{ matrix.os }}/${{ matrix.arch }}
         ( shopt -s nullglob && cp bitsandbytes/*.{so,dylib,dll} output/${{ matrix.os }}/${{ matrix.arch }}/ )
     - name: Upload build artifact
@@ -109,9 +106,10 @@ jobs:
         sub-packages: '["nvcc","cudart","cusparse","cublas","thrust","nvrtc_dev","cublas_dev","cusparse_dev"]'
         linux-local-args: '["--toolkit"]'
         use-github-cache: false
-    - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.1
-      if: ${{ startsWith(matrix.os, 'windows') }}
+    - name: Setup MSVC
+      if: startsWith(matrix.os, 'windows')
+      #uses: microsoft/setup-msbuild@v1.1 # to use msbuild
+      uses: ilammy/msvc-dev-cmd@v1.13.0 # to use cl
       # Compile C++ code
     - name: Build C++
       shell: bash
@@ -127,10 +125,11 @@ jobs:
               "apt-get update \
               && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends cmake \
               && cmake -DCOMPUTE_BACKEND=cuda -DNO_CUBLASLT=${NO_CUBLASLT} . \
-              && make"
+              && cmake --build ."
           else
-            cmake -DCOMPUTE_BACKEND=cuda -DNO_CUBLASLT=${NO_CUBLASLT} .
-            pwsh -Command "msbuild bitsandbytes.vcxproj /property:Configuration=Release"
+            python3 -m pip install cmake==3.27.9 ninja
+            cmake -G Ninja -DCOMPUTE_BACKEND=cuda -DNO_CUBLASLT=${NO_CUBLASLT} -DCMAKE_BUILD_TYPE=Release -S .
+            cmake --build . --config Release
           fi
         done
         mkdir -p output/${{ matrix.os }}/${{ matrix.arch }}


### PR DESCRIPTION
Currently, CI uses the [Jimver/cuda-toolkit](https://github.com/Jimver/cuda-toolkit) for Windows which has known speed issues when working on Windows.
https://github.com/Jimver/cuda-toolkit/issues/253

specific package `"visual_studio_integration"` is the cause of this speed issue but it is needed to use msbuild.

here is the solution.
- do not install `"visual_studio_integration"` sub-package
- compile using MSVC + ninja, instead of using msbuild.
- and also turn off `github-cache` for cuda-tools to fix some broken cases.
<details><summary>Cache error log for example.</summary>

https://github.com/TimDettmers/bitsandbytes/actions/runs/7804268267/job/21285853144
~~~bash
Run Jimver/cuda-toolkit@v0.[2](https://github.com/TimDettmers/bitsandbytes/actions/runs/7804268267/job/21285853144#step:5:2).14
  with:
    cuda: 12.1.0
    method: local
    sub-packages: []
    non-cuda-sub-packages: []
    linux-local-args: ["--toolkit", "--samples"]
    use-github-cache: true
    use-local-cache: true
    log-file-suffix: log.txt
"C:\Program Files\Git\usr\bin\tar.exe" --posix -cf cache.tzst --exclude cache.tzst -P -C D:/a/bitsandbytes/bitsandbytes --files-from manifest.txt --force-local --use-compress-program "zstd -T0"
Cache Size: ~[3](https://github.com/TimDettmers/bitsandbytes/actions/runs/7804268267/job/21285853144#step:5:3)195 MB (3350[4](https://github.com/TimDettmers/bitsandbytes/actions/runs/7804268267/job/21285853144#step:5:4)07[6](https://github.com/TimDettmers/bitsandbytes/actions/runs/7804268267/job/21285853144#step:5:6)[7](https://github.com/TimDettmers/bitsandbytes/actions/runs/7804268267/job/21285853144#step:5:7)4 B)
Cache saved successfully
Error: Error: Got no files in tool cahce
~~~

</details>

without this fix: total build time is about ~30 ~40min
with this fix: total build time will be reduced about ~25min
