### PR TITLE
Fix race condition in kEstimateQuantiles

### DIFF
--- a/csrc/kernels.cu
+++ b/csrc/kernels.cu
@@ -654,6 +654,8 @@ __global__ void kEstimateQuantiles(T *__restrict__ const A, float *code, const f
       for(int j = threadIdx.x; j < BLOCK_ESTIMATE; j+=blockDim.x)
           temp_storage.smem_qidx[j] = -1;
 
+      __syncthreads();
+
       if(threadIdx.x < 256)
       {
           float q_interval = (1.0f-(2.0f*offset))/255.0f;


### PR DESCRIPTION
Hi, there is a race condition in kEstimateQuantiles kernel and it needs additional synchronization step. The kernel is giving unexpected results on rocm because of this, this PR adds the sync step to avoid it.