### PR TITLE
fix cudart*dll for Windows

### DIFF
--- a/bitsandbytes/cuda_setup/main.py
+++ b/bitsandbytes/cuda_setup/main.py
@@ -30,7 +30,7 @@ from .env_vars import get_potentially_lib_path_containing_env_vars
 
 DYNAMIC_LIBRARY_SUFFIX = { "Darwin": ".dylib", "Windows": ".dll", "Linux": ".so"}.get(platform.system(), ".so")
 if platform.system() == "Windows":  # Windows
-    CUDA_RUNTIME_LIBS = ["nvcuda.dll"]
+    CUDA_RUNTIME_LIBS = ["cudart64_110.dll", "cudart64_12.dll"]
 else:  # Linux or other
     # these are the most common libs names
     # libcudart.so is missing by default for a conda install with PyTorch 2.0 and instead


### PR DESCRIPTION
`CUDA_RUNTIME_LIBS = ["nvcuda.dll"]` -> `binday_path` will get `c:\windows\system32` but this is not intended.

fix `CUDA_RUNTIME_LIBS = ["cudart64_110.dll", "cudart64_12.dll"]` to get `binary_path` such as `'C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\bin\cudart32_110.dll'` correctly.
