### PR TITLE
adding whole Linear8bitLt/Linear4bit module save/load serialization

### DIFF
--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -449,7 +449,9 @@ class Int8Params(torch.nn.Parameter):
         cls.SCB = None
         if data is None:
             data = torch.empty(0)
-        return torch.Tensor._make_subclass(cls, data, requires_grad)
+        obj = torch.Tensor._make_subclass(cls, data, requires_grad)
+        obj.CB, obj.SCB = cls.CB, cls.SCB
+        return obj
 
     def cuda(self, device):
         if self.has_fp16_weights:


### PR DESCRIPTION
The purpose of this pull request is to allow `torch.save`/`torch.load` directly on modules containing `Linear4bit` and `Linear8bitLt` submodules.

Currently, `torch.save`, then `torch.load` on `Linear8bitLt` (after first forward) causes a missing field `CB` error in the `Int8Params` class. This PR makes torch aware of the `CB` and `SCB` fields in `Int8Params` class.

The core of this PR is
```python
        ~~return torch.Tensor._make_subclass(cls, data, requires_grad)~~
        obj = torch.Tensor._make_subclass(cls, data, requires_grad)
        obj.CB, obj.SCB = cls.CB, cls.SCB
        return obj
```
in  `class Int8Params`

I also added the `torch.save` -> `torch.load` test to the `Linear4bit` (this was already working) and `Linear8bitLt` (this is not yet working).

While saving modules directly in Pytorch with `save` and `load` is not good practice, the change to make this work is minimal and makes disk caching modules for development easier.