### PR TITLE
Fix diagnostics error within vscode on windows

### DIFF
--- a/bitsandbytes/diagnostics/cuda.py
+++ b/bitsandbytes/diagnostics/cuda.py
@@ -59,7 +59,7 @@ def find_cuda_libraries_in_path_list(paths_list_candidate: str) -> Iterable[Path
                 for pth in dir.glob(lib_pattern):
                     if pth.is_file():
                         yield pth
-        except PermissionError:
+        except (OSError, PermissionError):
             pass
 
 


### PR DESCRIPTION
This fixes a small issue out of #1041 when running `python -m bitsandbytes` from an integrated VSCode terminal on Windows.

```
OSError: [WinError 231] All pipe instances are busy: '\\\\.\\pipe\\vscode-git-bc89f4fbf9-sock'
```