### PR TITLE
Tests: improve memory usage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import gc
+
 import pytest
 import torch
 
@@ -18,6 +20,13 @@ def pytest_runtest_call(item):
         if "Found no NVIDIA driver on your system" in str(re):
             pytest.skip("No NVIDIA driver found")
         raise
+
+
+@pytest.hookimpl(trylast=True)
+def pytest_runtest_teardown(item, nextitem):
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
This simple change frees up GPU memory after each unit test. Prior to this change, I would experience a system crash when attempting to run the full unit test suite on RTX 3060 6GB. It now runs comfortably.