### PR TITLE
[`Core`] Change 8-bit serialization weight format format

### DIFF
--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -14,7 +14,11 @@ import bitsandbytes as bnb
 from bitsandbytes.autograd._functions import get_tile_inds, undo_layout
 from bitsandbytes.functional import QuantState
 from bitsandbytes.optim import GlobalOptimManager
-from bitsandbytes.utils import LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING, INVERSE_LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING, OutlierTracer
+from bitsandbytes.utils import (
+    INVERSE_LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING,
+    LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING,
+    OutlierTracer,
+)
 
 T = TypeVar("T", bound="torch.nn.Module")
 

--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -14,7 +14,7 @@ import bitsandbytes as bnb
 from bitsandbytes.autograd._functions import get_tile_inds, undo_layout
 from bitsandbytes.functional import QuantState
 from bitsandbytes.optim import GlobalOptimManager
-from bitsandbytes.utils import OutlierTracer
+from bitsandbytes.utils import OutlierTracer, LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING
 
 T = TypeVar("T", bound="torch.nn.Module")
 
@@ -619,6 +619,18 @@ def maybe_rearrange_weight(state_dict, prefix, local_metadata, strict, missing_k
         return
     weight_format = state_dict.pop(f"{prefix}weight_format", "row")
 
+    if isinstance(weight_format, torch.Tensor):
+        weight_format = weight_format.item()
+
+    # For new weights format storage type we expclicitly check 
+    # if weights_format is on the mapping
+    if isinstance(weight_format, int) and not weight_format in LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING.values():
+        raise ValueError(
+            f"Expected supported weight format - got {weight_format}"
+        )
+    elif isinstance(weight_format, int) and weight_format in LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING.values():
+        weight_format = dict(zip(LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING.values(), LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING.keys()))[weight_format]
+
     if weight_format != "row":
         tile_indices = get_tile_inds(weight_format, weight.device)
         state_dict[f"{prefix}weight"] = undo_layout(weight, tile_indices)
@@ -711,13 +723,20 @@ class Linear8bitLt(nn.Linear):
         if not self.state.has_fp16_weights:
             if param_from_weight is not None:
                 destination[key_name] = param_from_weight if keep_vars else param_from_weight.detach()
-                destination[format_name] = "row"
+                destination[format_name] = torch.tensor(0, dtype=torch.uint8)
             elif param_from_state is not None and not layout_reordered:
                 destination[key_name] = param_from_state if keep_vars else param_from_state.detach()
-                destination[format_name] = "row"
+                destination[format_name] = torch.tensor(0, dtype=torch.uint8)
             elif param_from_state is not None:
                 destination[key_name] = param_from_state if keep_vars else param_from_state.detach()
-                destination[format_name] = self.state.formatB
+                weights_format = self.state.formatB
+                # At this point `weights_format` is an str
+                if weights_format not in LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING.keys():
+                    raise ValueError(f"Unrecognized weights format {weights_format}")
+
+                weights_format = LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING[weights_format]
+
+                destination[format_name] = torch.tensor(weights_format, dtype=torch.uint8)
 
     def _load_from_state_dict(
         self,

--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -14,7 +14,7 @@ import bitsandbytes as bnb
 from bitsandbytes.autograd._functions import get_tile_inds, undo_layout
 from bitsandbytes.functional import QuantState
 from bitsandbytes.optim import GlobalOptimManager
-from bitsandbytes.utils import LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING, OutlierTracer
+from bitsandbytes.utils import LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING, INVERSE_LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING, OutlierTracer
 
 T = TypeVar("T", bound="torch.nn.Module")
 
@@ -624,12 +624,10 @@ def maybe_rearrange_weight(state_dict, prefix, local_metadata, strict, missing_k
 
     # For new weights format storage type we expclicitly check
     # if weights_format is on the mapping
-    if isinstance(weight_format, int) and weight_format not in LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING.values():
+    if isinstance(weight_format, int) and weight_format not in INVERSE_LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING:
         raise ValueError(f"Expected supported weight format - got {weight_format}")
-    elif isinstance(weight_format, int) and weight_format in LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING.values():
-        weight_format = dict(
-            zip(LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING.values(), LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING.keys())
-        )[weight_format]
+    elif isinstance(weight_format, int) and weight_format in INVERSE_LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING:
+        weight_format = INVERSE_LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING[weight_format]
 
     if weight_format != "row":
         tile_indices = get_tile_inds(weight_format, weight.device)

--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -14,7 +14,7 @@ import bitsandbytes as bnb
 from bitsandbytes.autograd._functions import get_tile_inds, undo_layout
 from bitsandbytes.functional import QuantState
 from bitsandbytes.optim import GlobalOptimManager
-from bitsandbytes.utils import OutlierTracer, LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING
+from bitsandbytes.utils import LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING, OutlierTracer
 
 T = TypeVar("T", bound="torch.nn.Module")
 
@@ -622,14 +622,14 @@ def maybe_rearrange_weight(state_dict, prefix, local_metadata, strict, missing_k
     if isinstance(weight_format, torch.Tensor):
         weight_format = weight_format.item()
 
-    # For new weights format storage type we expclicitly check 
+    # For new weights format storage type we expclicitly check
     # if weights_format is on the mapping
-    if isinstance(weight_format, int) and not weight_format in LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING.values():
-        raise ValueError(
-            f"Expected supported weight format - got {weight_format}"
-        )
+    if isinstance(weight_format, int) and weight_format not in LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING.values():
+        raise ValueError(f"Expected supported weight format - got {weight_format}")
     elif isinstance(weight_format, int) and weight_format in LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING.values():
-        weight_format = dict(zip(LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING.values(), LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING.keys()))[weight_format]
+        weight_format = dict(
+            zip(LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING.values(), LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING.keys())
+        )[weight_format]
 
     if weight_format != "row":
         tile_indices = get_tile_inds(weight_format, weight.device)

--- a/bitsandbytes/utils.py
+++ b/bitsandbytes/utils.py
@@ -199,4 +199,5 @@ def unpack_tensor_to_dict(tensor_data):
 
     return unpacked_dict
 
+
 LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING = {"row": 0, "col32": 1, "col_turing": 2, "col_ampere": 3}

--- a/bitsandbytes/utils.py
+++ b/bitsandbytes/utils.py
@@ -199,9 +199,4 @@ def unpack_tensor_to_dict(tensor_data):
 
     return unpacked_dict
 
-LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING = {
-    "row": 0,
-    "col32": 1,
-    "col_turing": 2,
-    "col_ampere": 3
-}
+LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING = {"row": 0, "col32": 1, "col_turing": 2, "col_ampere": 3}

--- a/bitsandbytes/utils.py
+++ b/bitsandbytes/utils.py
@@ -198,3 +198,10 @@ def unpack_tensor_to_dict(tensor_data):
     unpacked_dict = json.loads(json_str)
 
     return unpacked_dict
+
+LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING = {
+    "row": 0,
+    "col32": 1,
+    "col_turing": 2,
+    "col_ampere": 3
+}

--- a/bitsandbytes/utils.py
+++ b/bitsandbytes/utils.py
@@ -201,3 +201,4 @@ def unpack_tensor_to_dict(tensor_data):
 
 
 LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING = {"row": 0, "col32": 1, "col_turing": 2, "col_ampere": 3}
+INVERSE_LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING = {val: name for (name, val) in LINEAR_8BIT_WEIGHTS_FORMAT_MAPPING.items()}


### PR DESCRIPTION
Currently for 8-bit layers the weight format are saved in pure str in the state dict, which is no longer supported in transformers

This PR should be totally backward compatible with previous 8-bit weights pushed on the Hub

cc @Titus-von-Koeller @TimDettmers @SunMarc 