### PR TITLE
Add CUDA 12.4 to Linux x86-64 Build Workflow

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -63,7 +63,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         arch: [x86_64, aarch64]
         cuda_version:
-          ["11.7.1", "11.8.0", "12.0.1", "12.1.1", "12.2.2", "12.3.2"]
+          ["11.7.1", "11.8.0", "12.0.1", "12.1.1", "12.2.2", "12.3.2", "12.4.0"]
         exclude:
           - os: windows-latest # This probably requires arm64 Windows agents
             arch: aarch64

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -67,6 +67,8 @@ jobs:
         exclude:
           - os: windows-latest # This probably requires arm64 Windows agents
             arch: aarch64
+          - os: windows-latest  # The Jimver/cuda-toolkit is action used for Windows builds is not updated for 12.4 yet.
+            cuda_version: "12.4.0"
           - os: ubuntu-latest # Temporary. Takes too long, not ready yet.
             arch: aarch64
     runs-on: ${{ matrix.os }} # One day, we could run them on native agents. Azure supports this now but it's planned only for Q3 2023 for hosted agents


### PR DESCRIPTION
It took a little while, but NVIDIA published the `nvidia/cuda:12.4.0-devel-ubuntu22.04` container. This PR enables building with CUDA 12.4.0 on Linux x86-64.

Windows builds use an action that hasn't been updated yet, so will need to enable at a future point.