### PR TITLE
FIX_ Prevent __getstate__ from mutating Params4bit

### DIFF
--- a/bitsandbytes/nn/modules.py
+++ b/bitsandbytes/nn/modules.py
@@ -236,7 +236,7 @@ class Params4bit(torch.nn.Parameter):
         return self
 
     def __getstate__(self):
-        state = self.__dict__
+        state = self.__dict__.copy()
         state["data"] = self.data
         state["requires_grad"] = self.requires_grad
         return state


### PR DESCRIPTION
As discussed internally, use `state = self.__dict__.copy()` inside `__getstate__`, which is also what the[ Python docs recommend](https://docs.python.org/3/library/pickle.html#handling-stateful-objects).

I did some more digging to understand why the `state` even needs to be updated. The reason is that during `__new__`, `torch.Tensor._make_subclass(cls, data, requires_grad)` is being used. This method apparently does not update the `__dict__`, which means that even though `self.data` and `self.requires_grad` exist, they are not part of the `__dict__`, hence requiring to update it manually in `__getstate__`.

As to why that is, I could not find any further information.

I ran the following tests:

- `pytest tests/test_linear4bit.py`
- in PEFT: `python -m pytest -m "single_gpu_tests and bitsandbytes" tests/test_gpu_examples.py`
- in PEFT: `python -m pytest -m "single_gpu_tests and bitsandbytes" tests/test_common_gpu.py`
- in transformers: `RUN_SLOW=1 python -m pytest tests/quantization/bnb -x`

I had a few failures but they are unrelated to this change (they happen even without the change). LMK if more testing is required.