### PR TITLE
provide temp flag for outside libs to detect multi-backend preview

### DIFF
--- a/bitsandbytes/__init__.py
+++ b/bitsandbytes/__init__.py
@@ -20,6 +20,13 @@ from .backends.npu import NPUBackend
 from .cextension import lib
 from .nn import modules
 
+# NOTE: this is a temporary flag to allow outside libraries to employ conditional logic while the refactor is still in
+# alpha/beta: sth like `if getattr(bitsandbytes, "multi-backend-refactor-preview", False): do sth`
+# the getattr() call above would default to False and any string evaluates to True. This way we have temporary thing
+# that we can remove in Transformers with the next release after the official BNB multi-platform release; then
+# eventually making it the new default (e.g. just remove if statement and dedent in Transformers)
+is_multi_backend_refactor_preview = "TO BE REMOVED ONCE MERGED TO `main`"  # bool evals to True for str
+
 # Always register the CPU backend.
 register_backend("cpu", CPUBackend())
 

--- a/bitsandbytes/__init__.py
+++ b/bitsandbytes/__init__.py
@@ -21,7 +21,7 @@ from .cextension import lib
 from .nn import modules
 
 # NOTE: this is a temporary flag to allow outside libraries to employ conditional logic while the refactor is still in
-# alpha/beta: sth like `if getattr(bitsandbytes, "multi-backend-refactor-preview", False): do sth`
+# alpha/beta: sth like `if getattr(bitsandbytes, "is_multi_backend_refactor_preview", False): do sth`
 # the getattr() call above would default to False and any string evaluates to True. This way we have temporary thing
 # that we can remove in Transformers with the next release after the official BNB multi-platform release; then
 # eventually making it the new default (e.g. just remove if statement and dedent in Transformers)


### PR DESCRIPTION
After internal discussion how to handle [this Transformers issue that came up when trying to test the alpha release in conjunction with the HF ecosystem](https://github.com/huggingface/transformers/issues/31248), this is a simple approach that could help outside libs detect if they're dealing with the BNB preview version.

Wdyt @younesbelkada @akx @matthewdouglas ?

Hmm, maybe setting it to True is cleaner.. Thought of the `str` before adding the extensive comment..

Added this snippet to `bnb/__init__.py`:
```python
# NOTE: this is a temporary flag to allow outside libraries to employ conditional logic while the refactor is still in
# alpha/beta: sth like `if getattr(bitsandbytes, "is_multi_backend_refactor_preview", False): do sth`
# the getattr() call above would default to False and any string evaluates to True. This way we have temporary thing
# that we can remove in Transformers with the next release after the official BNB multi-platform release; then
# eventually making it the new default (e.g. just remove if statement and dedent in Transformers)
is_multi_backend_refactor_preview = "TO BE REMOVED ONCE MERGED TO `main`"  # bool evals to True for str
```

```
In [1]: import bitsandbytes as bnb

In [2]: bnb.is_multi_backend_refactor_preview
Out[2]: 'TO BE REMOVED ONCE MERGED TO `main`'

In [3]: bool(getattr(bnb, "is_multi_backend_refactor_preview", False))
Out[3]: True

In [4]: del bnb.is_multi_backend_refactor_preview  # not defined on `main`

In [5]: getattr(bnb, "is_multi_backend_refactor_preview", False)
Out[5]: False
```