### PR TITLE
CPU/XPU: disable torch.compile if g++ is not available

### DIFF
--- a/bitsandbytes/backends/cpu_xpu_common.py
+++ b/bitsandbytes/backends/cpu_xpu_common.py
@@ -1,5 +1,6 @@
 from typing import Optional
 import warnings
+import subprocess
 
 import torch
 
@@ -17,6 +18,14 @@ try:
 except BaseException:
     ipex_cpu = None
     ipex_xpu = None
+
+
+gxx_available = False
+try:
+    subprocess.run(["g++", "--version"])
+    gxx_available = True
+except BaseException:
+    warnings.warn(f"g++ not found, torch.compile disabled for CPU/XPU.")
 
 
 Tensor = torch.Tensor
@@ -45,8 +54,8 @@ def _ipex_xpu_version_prereq(major, minor):
 
 
 def _maybe_torch_compile(func):
-    # torch.compile requires pytorch >= 2.0
-    if _torch_version_prereq(2, 0):
+    # torch.compile requires g++ and pytorch >= 2.0
+    if gxx_available and _torch_version_prereq(2, 0):
         options = {}
         # fx_graph_cache requires pytorch >= 2.2
         if _torch_version_prereq(2, 2):


### PR DESCRIPTION
`torch.compile` requires `g++`. On platforms like Windows, `g++` is not available. In that case, `torch.compile` is disabled to avoid runtime errors. With this patch, the CPU/XPU can be enabled on Windows.

I have validated the patch by running UTs for CPU backend in `test_functional.py` and a real model (OPT-1.3B) on my local machine (Windows 11 Enterprise, 12th Gen Intel(R) Core(TM) i7-1270P  2.20 GHz, 16.0 GB RAM).